### PR TITLE
fix: properly handle address status cleanup

### DIFF
--- a/internal/pkg/machine/controllers/address_spec.go
+++ b/internal/pkg/machine/controllers/address_spec.go
@@ -142,6 +142,10 @@ func (ctrl *AddressSpecController) Run(ctx context.Context, r controller.Runtime
 		}
 
 		if err = addresses.ForEachErr(func(res *network.AddressStatus) error {
+			if _, ok := visited[res.Metadata().ID()]; ok {
+				return nil
+			}
+
 			return r.Destroy(ctx, res.Metadata())
 		}); err != nil {
 			return err


### PR DESCRIPTION
The bug was causing all statuses to be destroyed.