### PR TITLE
feat: simulate reboots in the reboot and upgrade API

### DIFF
--- a/api/specs/specs.pb.go
+++ b/api/specs/specs.pb.go
@@ -12,6 +12,7 @@ import (
 
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -447,6 +448,93 @@ func (x *ServiceSpec) GetHealth() *ServiceSpec_Health {
 	return nil
 }
 
+// RebootSpec keeps track of all reboots on the node.
+type RebootSpec struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Downtime *durationpb.Duration `protobuf:"bytes,1,opt,name=downtime,proto3" json:"downtime,omitempty"`
+}
+
+func (x *RebootSpec) Reset() {
+	*x = RebootSpec{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_specs_specs_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RebootSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RebootSpec) ProtoMessage() {}
+
+func (x *RebootSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_specs_specs_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RebootSpec.ProtoReflect.Descriptor instead.
+func (*RebootSpec) Descriptor() ([]byte, []int) {
+	return file_specs_specs_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RebootSpec) GetDowntime() *durationpb.Duration {
+	if x != nil {
+		return x.Downtime
+	}
+	return nil
+}
+
+// RebootStatusSpec is generated for each reboot spec.
+type RebootStatusSpec struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *RebootStatusSpec) Reset() {
+	*x = RebootStatusSpec{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_specs_specs_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RebootStatusSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RebootStatusSpec) ProtoMessage() {}
+
+func (x *RebootStatusSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_specs_specs_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RebootStatusSpec.ProtoReflect.Descriptor instead.
+func (*RebootStatusSpec) Descriptor() ([]byte, []int) {
+	return file_specs_specs_proto_rawDescGZIP(), []int{8}
+}
+
 type ServiceSpec_Health struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -461,7 +549,7 @@ type ServiceSpec_Health struct {
 func (x *ServiceSpec_Health) Reset() {
 	*x = ServiceSpec_Health{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_specs_specs_proto_msgTypes[8]
+		mi := &file_specs_specs_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -474,7 +562,7 @@ func (x *ServiceSpec_Health) String() string {
 func (*ServiceSpec_Health) ProtoMessage() {}
 
 func (x *ServiceSpec_Health) ProtoReflect() protoreflect.Message {
-	mi := &file_specs_specs_proto_msgTypes[8]
+	mi := &file_specs_specs_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -524,7 +612,9 @@ var file_specs_specs_proto_rawDesc = []byte{
 	0x0a, 0x11, 0x73, 0x70, 0x65, 0x63, 0x73, 0x2f, 0x73, 0x70, 0x65, 0x63, 0x73, 0x2e, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x12, 0x05, 0x73, 0x70, 0x65, 0x63, 0x73, 0x1a, 0x1f, 0x67, 0x6f, 0x6f, 0x67,
 	0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x74, 0x69, 0x6d, 0x65,
-	0x73, 0x74, 0x61, 0x6d, 0x70, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xc4, 0x01, 0x0a, 0x11,
+	0x73, 0x74, 0x61, 0x6d, 0x70, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1e, 0x67, 0x6f, 0x6f,
+	0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x64, 0x75, 0x72,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xc4, 0x01, 0x0a, 0x11,
 	0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x53, 0x70, 0x65,
 	0x63, 0x12, 0x22, 0x0a, 0x0c, 0x62, 0x6f, 0x6f, 0x74, 0x73, 0x74, 0x72, 0x61, 0x70, 0x70, 0x65,
 	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0c, 0x62, 0x6f, 0x6f, 0x74, 0x73, 0x74, 0x72,
@@ -583,10 +673,15 @@ var file_specs_specs_proto_rawDesc = []byte{
 	0x5f, 0x63, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e,
 	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
 	0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x0a, 0x6c, 0x61, 0x73, 0x74, 0x43,
-	0x68, 0x61, 0x6e, 0x67, 0x65, 0x42, 0x28, 0x5a, 0x26, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
-	0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x69, 0x64, 0x65, 0x72, 0x6f, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x74,
-	0x61, 0x6c, 0x65, 0x6d, 0x75, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x73, 0x70, 0x65, 0x63, 0x73, 0x62,
-	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x68, 0x61, 0x6e, 0x67, 0x65, 0x22, 0x43, 0x0a, 0x0a, 0x52, 0x65, 0x62, 0x6f, 0x6f, 0x74, 0x53,
+	0x70, 0x65, 0x63, 0x12, 0x35, 0x0a, 0x08, 0x64, 0x6f, 0x77, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x44, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x52, 0x08, 0x64, 0x6f, 0x77, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x22, 0x12, 0x0a, 0x10, 0x52, 0x65,
+	0x62, 0x6f, 0x6f, 0x74, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x53, 0x70, 0x65, 0x63, 0x42, 0x28,
+	0x5a, 0x26, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x69, 0x64,
+	0x65, 0x72, 0x6f, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x74, 0x61, 0x6c, 0x65, 0x6d, 0x75, 0x2f, 0x61,
+	0x70, 0x69, 0x2f, 0x73, 0x70, 0x65, 0x63, 0x73, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -601,7 +696,7 @@ func file_specs_specs_proto_rawDescGZIP() []byte {
 	return file_specs_specs_proto_rawDescData
 }
 
-var file_specs_specs_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_specs_specs_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_specs_specs_proto_goTypes = []any{
 	(*ClusterStatusSpec)(nil),     // 0: specs.ClusterStatusSpec
 	(*MachineStatusSpec)(nil),     // 1: specs.MachineStatusSpec
@@ -610,19 +705,23 @@ var file_specs_specs_proto_goTypes = []any{
 	(*ImageSpec)(nil),             // 4: specs.ImageSpec
 	(*CachedImageSpec)(nil),       // 5: specs.CachedImageSpec
 	(*ServiceSpec)(nil),           // 6: specs.ServiceSpec
-	nil,                           // 7: specs.EventSinkStateSpec.VersionsEntry
-	(*ServiceSpec_Health)(nil),    // 8: specs.ServiceSpec.Health
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*RebootSpec)(nil),            // 7: specs.RebootSpec
+	(*RebootStatusSpec)(nil),      // 8: specs.RebootStatusSpec
+	nil,                           // 9: specs.EventSinkStateSpec.VersionsEntry
+	(*ServiceSpec_Health)(nil),    // 10: specs.ServiceSpec.Health
+	(*durationpb.Duration)(nil),   // 11: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil), // 12: google.protobuf.Timestamp
 }
 var file_specs_specs_proto_depIdxs = []int32{
-	7, // 0: specs.EventSinkStateSpec.versions:type_name -> specs.EventSinkStateSpec.VersionsEntry
-	8, // 1: specs.ServiceSpec.health:type_name -> specs.ServiceSpec.Health
-	9, // 2: specs.ServiceSpec.Health.last_change:type_name -> google.protobuf.Timestamp
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	9,  // 0: specs.EventSinkStateSpec.versions:type_name -> specs.EventSinkStateSpec.VersionsEntry
+	10, // 1: specs.ServiceSpec.health:type_name -> specs.ServiceSpec.Health
+	11, // 2: specs.RebootSpec.downtime:type_name -> google.protobuf.Duration
+	12, // 3: specs.ServiceSpec.Health.last_change:type_name -> google.protobuf.Timestamp
+	4,  // [4:4] is the sub-list for method output_type
+	4,  // [4:4] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_specs_specs_proto_init() }
@@ -715,7 +814,31 @@ func file_specs_specs_proto_init() {
 				return nil
 			}
 		}
+		file_specs_specs_proto_msgTypes[7].Exporter = func(v any, i int) any {
+			switch v := v.(*RebootSpec); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 		file_specs_specs_proto_msgTypes[8].Exporter = func(v any, i int) any {
+			switch v := v.(*RebootStatusSpec); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_specs_specs_proto_msgTypes[10].Exporter = func(v any, i int) any {
 			switch v := v.(*ServiceSpec_Health); i {
 			case 0:
 				return &v.state
@@ -734,7 +857,7 @@ func file_specs_specs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_specs_specs_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/specs/specs.proto
+++ b/api/specs/specs.proto
@@ -4,6 +4,7 @@ package specs;
 option go_package = "github.com/siderolabs/talemu/api/specs";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 // ClusterStatusSpec defines cluster status of the emulator.
 message ClusterStatusSpec {
@@ -58,3 +59,11 @@ message ServiceSpec {
   string state = 2;
   Health health = 3;
 }
+
+// RebootSpec keeps track of all reboots on the node.
+message RebootSpec {
+  google.protobuf.Duration downtime = 1;
+}
+
+// RebootStatusSpec is generated for each reboot spec.
+message RebootStatusSpec {}

--- a/api/specs/specs_vtproto.pb.go
+++ b/api/specs/specs_vtproto.pb.go
@@ -9,9 +9,11 @@ import (
 	io "io"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
+	durationpb1 "github.com/planetscale/vtprotobuf/types/known/durationpb"
 	timestamppb1 "github.com/planetscale/vtprotobuf/types/known/timestamppb"
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -187,6 +189,39 @@ func (m *ServiceSpec) CloneVT() *ServiceSpec {
 }
 
 func (m *ServiceSpec) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *RebootSpec) CloneVT() *RebootSpec {
+	if m == nil {
+		return (*RebootSpec)(nil)
+	}
+	r := new(RebootSpec)
+	r.Downtime = (*durationpb.Duration)((*durationpb1.Duration)(m.Downtime).CloneVT())
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *RebootSpec) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *RebootStatusSpec) CloneVT() *RebootStatusSpec {
+	if m == nil {
+		return (*RebootStatusSpec)(nil)
+	}
+	r := new(RebootStatusSpec)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *RebootStatusSpec) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -400,6 +435,41 @@ func (this *ServiceSpec) EqualVT(that *ServiceSpec) bool {
 
 func (this *ServiceSpec) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ServiceSpec)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *RebootSpec) EqualVT(that *RebootSpec) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !(*durationpb1.Duration)(this.Downtime).EqualVT((*durationpb1.Duration)(that.Downtime)) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *RebootSpec) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*RebootSpec)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *RebootStatusSpec) EqualVT(that *RebootStatusSpec) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *RebootStatusSpec) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*RebootStatusSpec)
 	if !ok {
 		return false
 	}
@@ -846,6 +916,82 @@ func (m *ServiceSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *RebootSpec) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RebootSpec) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *RebootSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Downtime != nil {
+		size, err := (*durationpb1.Duration)(m.Downtime).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RebootStatusSpec) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RebootStatusSpec) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *RebootStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ClusterStatusSpec) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1012,6 +1158,30 @@ func (m *ServiceSpec) SizeVT() (n int) {
 		l = m.Health.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *RebootSpec) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Downtime != nil {
+		l = (*durationpb1.Duration)(m.Downtime).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *RebootStatusSpec) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	n += len(m.unknownFields)
 	return n
 }
@@ -2122,6 +2292,144 @@ func (m *ServiceSpec) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RebootSpec) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RebootSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RebootSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Downtime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Downtime == nil {
+				m.Downtime = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.Downtime).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RebootStatusSpec) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RebootStatusSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RebootStatusSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/pkg/machine/controllers/reboot_status.go
+++ b/internal/pkg/machine/controllers/reboot_status.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+// RebootStatusController simulates node reboots by creating and removing reboot status resource.
+type RebootStatusController = qtransform.QController[*talos.Reboot, *talos.RebootStatus]
+
+// NewRebootStatusController creates new controller.
+func NewRebootStatusController() *RebootStatusController {
+	return qtransform.NewQController(
+		qtransform.Settings[*talos.Reboot, *talos.RebootStatus]{
+			Name: "talos.RebootStatus",
+			MapMetadataFunc: func(r *talos.Reboot) *talos.RebootStatus {
+				return talos.NewRebootStatus(r.Metadata().Namespace(), r.Metadata().ID())
+			},
+			UnmapMetadataFunc: func(r *talos.RebootStatus) *talos.Reboot {
+				return talos.NewReboot(r.Metadata().Namespace(), r.Metadata().ID())
+			},
+			TransformFunc: func(_ context.Context, _ controller.Reader, _ *zap.Logger, reboot *talos.Reboot, _ *talos.RebootStatus) error {
+				rebootEndTime := reboot.Metadata().Updated().Add(reboot.TypedSpec().Value.Downtime.AsDuration())
+				if time.Now().Before(rebootEndTime) {
+					return controller.NewRequeueInterval(time.Since(rebootEndTime))
+				}
+
+				return xerrors.NewTaggedf[qtransform.DestroyOutputTag]("reboot done")
+			},
+		},
+	)
+}

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/jsimonetti/rtnetlink"
-	factoryconsts "github.com/siderolabs/image-factory/pkg/constants"
-	"github.com/siderolabs/image-factory/pkg/schematic"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -85,7 +83,7 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, m
 
 	m.runtime = rt
 
-	resources := make([]resource.Resource, 0, 13)
+	resources := make([]resource.Resource, 0, 12)
 
 	// populate the initial machine state
 	hardwareInformation := hardware.NewSystemInformation(hardware.SystemInformationID)
@@ -126,28 +124,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, m
 	eventSinkConfig := runtime.NewEventSinkConfig()
 	eventSinkConfig.TypedSpec().Endpoint = siderolinkParams.EventsEndpoint
 
-	helloWorldExtension := runtime.NewExtensionStatus(runtime.NamespaceName, "hello-world-service")
-	helloWorldExtension.TypedSpec().Metadata.Name = "hello-world-service"
-	helloWorldExtension.TypedSpec().Metadata.Version = "v1.0.0"
-
-	schematic := schematic.Schematic{
-		Customization: schematic.Customization{
-			SystemExtensions: schematic.SystemExtensions{
-				OfficialExtensions: []string{
-					"hello-world-service",
-				},
-			},
-		},
-	}
-
-	schematicInfo := runtime.NewExtensionStatus(runtime.NamespaceName, factoryconsts.SchematicIDExtensionName)
-	schematicInfo.TypedSpec().Metadata.Name = factoryconsts.SchematicIDExtensionName
-
-	schematicInfo.TypedSpec().Metadata.Version, err = schematic.ID()
-	if err != nil {
-		return err
-	}
-
 	defaultRoute := network.NewRouteStatus(network.NamespaceName, "inet4/192.168.0.1//1024")
 	defaultRoute.TypedSpec().Family = nethelpers.FamilyInet4
 	defaultRoute.TypedSpec().Source = netip.MustParseAddr("192.168.0.1")
@@ -181,8 +157,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, m
 		trustdEndpoint,
 		eventSinkConfig,
 		disk,
-		schematicInfo,
-		helloWorldExtension,
 		defaultRoute,
 		memory,
 	)

--- a/internal/pkg/machine/runtime/resources/talos/reboot.go
+++ b/internal/pkg/machine/runtime/resources/talos/reboot.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/talemu/api/specs"
+)
+
+// NewReboot creates new Reboot resource.
+func NewReboot(ns, id string) *Reboot {
+	return typed.NewResource[RebootSpec, RebootExtension](
+		resource.NewMetadata(ns, RebootType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.RebootSpec{}),
+	)
+}
+
+const (
+	// RebootType is the type of Reboot resource.
+	RebootType = resource.Type("Reboots.talemu.sidero.dev")
+)
+
+// Reboot is used to simulate reboots.
+type Reboot = typed.Resource[RebootSpec, RebootExtension]
+
+// RebootSpec wraps specs.RebootSpec.
+type RebootSpec = protobuf.ResourceSpec[specs.RebootSpec, *specs.RebootSpec]
+
+// RebootExtension providers auxiliary methods for Reboot resource.
+type RebootExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (RebootExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             RebootType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns:     []meta.PrintColumn{},
+	}
+}

--- a/internal/pkg/machine/runtime/resources/talos/reboot_status.go
+++ b/internal/pkg/machine/runtime/resources/talos/reboot_status.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/talemu/api/specs"
+)
+
+// NewRebootStatus creates new RebootStatus resource.
+func NewRebootStatus(ns, id string) *RebootStatus {
+	return typed.NewResource[RebootStatusSpec, RebootStatusExtension](
+		resource.NewMetadata(ns, RebootStatusType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.RebootStatusSpec{}),
+	)
+}
+
+const (
+	// RebootStatusType is the type of RebootStatus resource.
+	RebootStatusType = resource.Type("RebootStatuses.talemu.sidero.dev")
+
+	// RebootID is the ID of the singleton represeting rebooting state.
+	RebootID = resource.ID("current")
+)
+
+// RebootStatus is used to simulate reboots.
+type RebootStatus = typed.Resource[RebootStatusSpec, RebootStatusExtension]
+
+// RebootStatusSpec wraps specs.RebootStatusSpec.
+type RebootStatusSpec = protobuf.ResourceSpec[specs.RebootStatusSpec, *specs.RebootStatusSpec]
+
+// RebootStatusExtension providers auxiliary methods for RebootStatus resource.
+type RebootStatusExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (RebootStatusExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             RebootStatusType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns:     []meta.PrintColumn{},
+	}
+}

--- a/internal/pkg/machine/runtime/resources/talos/resources.go
+++ b/internal/pkg/machine/runtime/resources/talos/resources.go
@@ -22,6 +22,8 @@ func init() {
 	mustRegisterResource(EventSinkStateType, &EventSinkState{})
 	mustRegisterResource(ImageType, &Image{})
 	mustRegisterResource(VersionType, &Version{})
+	mustRegisterResource(RebootType, &Reboot{})
+	mustRegisterResource(RebootStatusType, &RebootStatus{})
 }
 
 var resources []generic.ResourceWithRD

--- a/internal/pkg/machine/runtime/resources/talos/talos.go
+++ b/internal/pkg/machine/runtime/resources/talos/talos.go
@@ -183,6 +183,8 @@ func Register(ctx context.Context, state state.State) error {
 		&Disk{},
 		&Image{},
 		&Version{},
+		&Reboot{},
+		&RebootStatus{},
 	} {
 		if err := resourceRegistry.Register(ctx, r); err != nil {
 			return err

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -63,6 +63,10 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, machineIndex int, globa
 		return nil, err
 	}
 
+	qcontrollers := []controller.QController{
+		controllers.NewRebootStatusController(),
+	}
+
 	controllers := []controller.Controller{
 		&controllers.ManagerController{
 			MachineIndex: machineIndex,
@@ -137,6 +141,12 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, machineIndex int, globa
 
 	for _, ctrl := range controllers {
 		if err = runtime.RegisterController(ctrl); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, ctrl := range qcontrollers {
+		if err = runtime.RegisterQController(ctrl); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
With that change `TalosUpgrade` Omni tests start to pass.

Introduce `Reboot` and `RebootStatus` resources.
If `RebootStatus` exist the `apid` controller brings down it's service.

`Reboot` resource is configurable and can be used to set the downtime interval.

Also support statically defined schematic IDs to simulate extensions installation.