### PR TITLE
feat: correctly support unique token flow in the emulator

### DIFF
--- a/internal/pkg/machine/controllers/unique_token.go
+++ b/internal/pkg/machine/controllers/unique_token.go
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/siderolabs/gen/optional"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"go.uber.org/zap"
+)
+
+// UniqueMachineTokenController simulates node reboots by creating and removing reboot status resource.
+type UniqueMachineTokenController = qtransform.QController[*runtime.MetaKey, *runtime.UniqueMachineToken]
+
+// NewUniqueMachineTokenController creates new controller.
+func NewUniqueMachineTokenController() *UniqueMachineTokenController {
+	return qtransform.NewQController(
+		qtransform.Settings[*runtime.MetaKey, *runtime.UniqueMachineToken]{
+			Name: "runtime.UniqueMachineToken",
+			MapMetadataOptionalFunc: func(r *runtime.MetaKey) optional.Optional[*runtime.UniqueMachineToken] {
+				if r.Metadata().ID() != runtime.MetaKeyTagToID(16) {
+					return optional.None[*runtime.UniqueMachineToken]()
+				}
+
+				return optional.Some(runtime.NewUniqueMachineToken())
+			},
+			UnmapMetadataFunc: func(*runtime.UniqueMachineToken) *runtime.MetaKey {
+				return runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(16))
+			},
+			TransformFunc: func(_ context.Context, _ controller.Reader, _ *zap.Logger, metaKey *runtime.MetaKey, output *runtime.UniqueMachineToken) error {
+				if metaKey.Metadata().ID() != runtime.MetaKeyTagToID(16) {
+					return xerrors.NewTaggedf[qtransform.DestroyOutputTag]("not the unique token key")
+				}
+
+				output.TypedSpec().Token = metaKey.TypedSpec().Value
+
+				return nil
+			},
+		},
+	)
+}

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -94,7 +94,7 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 	m.runtime = rt
 
-	resources := make([]resource.Resource, 0, 12)
+	resources := make([]resource.Resource, 0, 11)
 
 	// populate the initial machine state
 	hardwareInformation := hardware.NewSystemInformation(hardware.SystemInformationID)
@@ -108,9 +108,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	siderolinkConfig.TypedSpec().Host = siderolinkParams.Host
 	siderolinkConfig.TypedSpec().Insecure = siderolinkParams.Insecure
 	siderolinkConfig.TypedSpec().Tunnel = siderolinkParams.TunnelMode
-
-	uniqueMachineToken := runtime.NewUniqueMachineToken()
-	uniqueMachineToken.TypedSpec().Token = m.uuid
 
 	platformMetadata := runtime.NewPlatformMetadataSpec(runtime.NamespaceName, runtime.PlatformMetadataID)
 	platformMetadata.TypedSpec().Platform = "metal"
@@ -161,7 +158,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	resources = append(resources,
 		hardwareInformation,
 		siderolinkConfig,
-		uniqueMachineToken,
 		platformMetadata,
 		processorInfo,
 		securityState,

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -63,6 +63,7 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 
 	qcontrollers := []controller.QController{
 		controllers.NewRebootStatusController(),
+		controllers.NewUniqueMachineTokenController(),
 	}
 
 	controllers := []controller.Controller{


### PR DESCRIPTION
Run the machine without any token first, then make it reconnect to siderolink when it gets the meta write with the right key.