### PR TITLE
fix: make Talemu more reliable in the CI

### DIFF
--- a/internal/pkg/machine/controllers/link_status.go
+++ b/internal/pkg/machine/controllers/link_status.go
@@ -47,6 +47,11 @@ func (ctrl *LinkStatusController) Inputs() []controller.Input {
 			Type:      network.LinkSpecType,
 			Kind:      controller.InputStrong,
 		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.LinkRefreshType,
+			Kind:      controller.InputWeak,
+		},
 	}
 }
 


### PR DESCRIPTION
It looks like `LinkStatusController` was missing `LinkRefreshType` input for some reason.