### PR TITLE
refactor: add --disable-node-proxying flag to apid director

### DIFF
--- a/cmd/talemu-infra-provider/main.go
+++ b/cmd/talemu-infra-provider/main.go
@@ -128,7 +128,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService); err != nil {
+		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService, cfg.nodeProxyingDisabled); err != nil {
 			return err
 		}
 
@@ -216,6 +216,7 @@ var cfg struct {
 	kernelArgs           string
 	schematicCacheDir    string
 	createServiceAccount bool
+	nodeProxyingDisabled bool
 }
 
 func main() {
@@ -239,4 +240,6 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.schematicCacheDir, "schematic-cache-dir", "/tmp/talemu-schematics", "the directory to use for caching schematics")
 	rootCmd.Flags().BoolVar(&cfg.createServiceAccount, "create-service-account", false,
 		"try creating service account for itself (works only if Omni is running in debug mode)")
+	rootCmd.Flags().BoolVar(&cfg.nodeProxyingDisabled, "disable-node-proxying", false,
+		"disable node-to-node proxying in apid: rejects the 'node' header, validates that a single-entry 'nodes' header targets this node, multi-node 'nodes' is still proxied")
 }

--- a/cmd/talemu/main.go
+++ b/cmd/talemu/main.go
@@ -112,7 +112,8 @@ var rootCmd = &cobra.Command{
 			}
 
 			eg.Go(func() error {
-				return m.Run(ctx, params, i+1000, kubernetes, machine.WithNetworkClient(nc), machine.WithTalosVersion(cfg.talosVersion), machine.WithSchematic(initialSchematicID))
+				return m.Run(ctx, params, i+1000, kubernetes, machine.WithNetworkClient(nc), machine.WithTalosVersion(cfg.talosVersion),
+					machine.WithSchematic(initialSchematicID), machine.WithNodeProxyingDisabled(cfg.nodeProxyingDisabled))
 			})
 
 			machines = append(machines, m)
@@ -176,11 +177,12 @@ func buildInitialSchematicID() (string, error) {
 }
 
 var cfg struct {
-	kernelArgs        string
-	talosVersion      string
-	schematicCacheDir string
-	extensions        []string
-	machinesCount     int
+	kernelArgs           string
+	talosVersion         string
+	schematicCacheDir    string
+	extensions           []string
+	machinesCount        int
+	nodeProxyingDisabled bool
 }
 
 func main() {
@@ -202,4 +204,6 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.talosVersion, "talos-version", constants.DefaultTalosVersion, "specify the Talos version to use")
 	rootCmd.Flags().StringVar(&cfg.schematicCacheDir, "schematic-cache-dir", "/tmp/talemu-schematics", "the directory to use for caching schematics")
 	rootCmd.Flags().IntVar(&cfg.machinesCount, "machines", 1, "the number of machines to emulate")
+	rootCmd.Flags().BoolVar(&cfg.nodeProxyingDisabled, "disable-node-proxying", false,
+		"disable node-to-node proxying in apid: rejects the 'node' header, validates that a single-entry 'nodes' header targets this node, multi-node 'nodes' is still proxied")
 }

--- a/internal/pkg/machine/controllers/node_address.go
+++ b/internal/pkg/machine/controllers/node_address.go
@@ -72,11 +72,18 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 			return err
 		}
 
+		// Collect all real addresses from AddressSpec resources (includes SideroLink, etc.),
+		// matching real Talos behavior where NodeAddressCurrent contains all current interface addresses.
+		realAddrs := make([]netip.Prefix, 0, addresses.Len())
+
+		addresses.ForEach(func(r *network.AddressSpec) {
+			realAddrs = append(realAddrs, r.TypedSpec().Address)
+		})
+
 		for _, id := range []string{
 			network.NodeAddressCurrentID,
 			network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s),
 		} {
-			// create fake virtual ipv6 addresses
 			if err = safe.WriterModify(ctx, r, network.NewNodeAddress(network.NamespaceName, id), func(r *network.NodeAddress) error {
 				var addr netip.Prefix
 
@@ -85,7 +92,7 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 					return err
 				}
 
-				r.TypedSpec().Addresses = []netip.Prefix{addr}
+				r.TypedSpec().Addresses = append([]netip.Prefix{addr}, realAddrs...)
 
 				return nil
 			}); err != nil {

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -102,7 +102,7 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 	m.logger = zap.New(core).With(zap.String("machine", m.uuid))
 
-	rt, err := truntime.NewRuntime(ctx, m.logger, slot, m.uuid, m.globalState, kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService)
+	rt, err := truntime.NewRuntime(ctx, m.logger, slot, m.uuid, m.globalState, kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService, opts.nodeProxyingDisabled)
 	if err != nil {
 		return fmt.Errorf("COSI runtime creation failed: %w", err)
 	}

--- a/internal/pkg/machine/options.go
+++ b/internal/pkg/machine/options.go
@@ -12,10 +12,11 @@ import (
 
 // Options is the extra machine options.
 type Options struct {
-	nc           *network.Client
-	talosVersion string
-	schematic    string
-	secureBoot   bool
+	nc                   *network.Client
+	talosVersion         string
+	schematic            string
+	secureBoot           bool
+	nodeProxyingDisabled bool
 }
 
 // Option represents a single extra machine option.
@@ -50,5 +51,14 @@ func WithNetworkClient(nc *network.Client) Option {
 func WithSecureBoot(value bool) Option {
 	return func(o *Options) {
 		o.secureBoot = value
+	}
+}
+
+// WithNodeProxyingDisabled disables node-to-node proxying in apid.
+// When set, apid rejects single-node forwarding via the "node" header
+// and only accepts direct connections from Omni via SideroLink.
+func WithNodeProxyingDisabled(value bool) Option {
+	return func(o *Options) {
+		o.nodeProxyingDisabled = value
 	}
 }

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
 	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
@@ -25,21 +26,24 @@ import (
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/emu"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
 	"github.com/siderolabs/talemu/internal/pkg/machine/services"
+	"github.com/siderolabs/talemu/internal/pkg/machine/services/apid/pkg/director"
 	"github.com/siderolabs/talemu/internal/pkg/schematic"
 )
 
 // Runtime handles COSI state setup and lifecycle.
 type Runtime struct {
-	state        state.State
-	globalState  state.State
-	runtime      *runtime.Runtime
-	backingStore io.Closer
-	id           string
+	state                state.State
+	globalState          state.State
+	backingStore         io.Closer
+	runtime              *runtime.Runtime
+	localAddressProvider *director.LocalAddrProvider
+	id                   string
 }
 
 // NewRuntime creates new runtime.
 func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, globalState state.State,
 	kubernetes *kubefactory.Kubernetes, nc *network.Client, logSink *logging.ZapCore, baseKernelArgs string, schematicService *schematic.Service,
+	nodeProxyingDisabled bool,
 ) (*Runtime, error) {
 	stateDir := GetStateDir(id)
 
@@ -67,6 +71,11 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 		controllers.NewUniqueMachineTokenController(),
 	}
 
+	localAddressProvider, err := director.NewLocalAddressProvider(st)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local address provider: %w", err)
+	}
+
 	controllers := []controller.Controller{
 		&controllers.ManagerController{
 			Slot: slot,
@@ -79,7 +88,7 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 			NC: nc,
 		},
 		&controllers.APIDController{
-			APID: services.NewAPID(id, st, globalState),
+			APID: services.NewAPID(id, st, globalState, localAddressProvider, nodeProxyingDisabled),
 		},
 		&controllers.AddressSpecController{
 			NC: nc,
@@ -166,11 +175,12 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 	}
 
 	return &Runtime{
-		state:        st,
-		globalState:  globalState,
-		runtime:      runtime,
-		backingStore: backingStore,
-		id:           id,
+		state:                st,
+		globalState:          globalState,
+		runtime:              runtime,
+		backingStore:         backingStore,
+		id:                   id,
+		localAddressProvider: localAddressProvider,
 	}, nil
 }
 
@@ -178,11 +188,25 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 func (r *Runtime) Run(ctx context.Context) error {
 	defer r.backingStore.Close() //nolint:errcheck
 
-	if err := r.runtime.Run(ctx); err != nil {
-		return err
-	}
+	eg, ctx := errgroup.WithContext(ctx)
 
-	return nil
+	eg.Go(func() error {
+		if err := r.localAddressProvider.Run(ctx); err != nil {
+			return fmt.Errorf("failed to run local address provider: %w", err)
+		}
+
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := r.runtime.Run(ctx); err != nil {
+			return fmt.Errorf("failed to run runtime: %w", err)
+		}
+
+		return nil
+	})
+
+	return eg.Wait()
 }
 
 // State returns COSI state.

--- a/internal/pkg/machine/services/apid.go
+++ b/internal/pkg/machine/services/apid.go
@@ -45,19 +45,23 @@ import (
 
 // APID is the emulated APId Talos service.
 type APID struct {
-	state       state.State
-	globalState state.State
-	shutdown    chan struct{}
-	eg          *errgroup.Group
-	machineID   string
+	state                state.State
+	globalState          state.State
+	localAddressProvider director.LocalAddressProvider
+	shutdown             chan struct{}
+	eg                   *errgroup.Group
+	machineID            string
+	nodeProxyingDisabled bool
 }
 
 // NewAPID creates new APID.
-func NewAPID(machineID string, state state.State, globalState state.State) *APID {
+func NewAPID(machineID string, state state.State, globalState state.State, localAddressProvider director.LocalAddressProvider, nodeProxyingDisabled bool) *APID {
 	return &APID{
-		machineID:   machineID,
-		state:       state,
-		globalState: globalState,
+		machineID:            machineID,
+		state:                state,
+		globalState:          globalState,
+		localAddressProvider: localAddressProvider,
+		nodeProxyingDisabled: nodeProxyingDisabled,
 	}
 }
 
@@ -89,7 +93,7 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	}
 
 	provider := NewTLSProvider()
-	if err = provider.Update(net.IP(endpoint.Addr().AsSlice()), apiCerts); err != nil {
+	if err = provider.Update(endpoint.Addr().AsSlice(), apiCerts); err != nil {
 		return err
 	}
 
@@ -105,18 +109,12 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	tlsCredentials := credentials.NewTLS(cfg)
 
 	backendFactory := backend.NewAPIDFactory(provider)
-	remoteFactory := backendFactory.Get
-
-	localAddressProvider, err := director.NewLocalAddressProvider(ctx, apid.state)
-	if err != nil {
-		return fmt.Errorf("failed to create local address provider: %w", err)
-	}
 
 	memconn := backend.NewTransport(apid.machineID)
 
 	localBackend := backend.NewLocal("machined", memconn)
 
-	router := director.NewRouter(remoteFactory, localBackend, localAddressProvider)
+	router := director.NewRouter(backendFactory.Get, localBackend, apid.localAddressProvider, apid.nodeProxyingDisabled)
 
 	// all existing streaming methods
 	for _, methodName := range []string{
@@ -384,7 +382,7 @@ func (provider *TLSProvider) ClientConfig() (*stdlibtls.Config, error) {
 
 	if ca == nil || clientCert == nil {
 		return &stdlibtls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, //nolint:gosec
 		}, nil
 	}
 

--- a/internal/pkg/machine/services/apid/pkg/director/director.go
+++ b/internal/pkg/machine/services/apid/pkg/director/director.go
@@ -24,17 +24,19 @@ type Router struct {
 	remoteBackendFactory RemoteBackendFactory
 	localAddressProvider LocalAddressProvider
 	streamedMatchers     []*regexp.Regexp
+	nodeProxyingDisabled bool
 }
 
 // RemoteBackendFactory provides backend generation by address (target).
 type RemoteBackendFactory func(target string) (proxy.Backend, error)
 
 // NewRouter builds new Router.
-func NewRouter(backendFactory RemoteBackendFactory, localBackend proxy.Backend, localAddressProvider LocalAddressProvider) *Router {
+func NewRouter(backendFactory RemoteBackendFactory, localBackend proxy.Backend, localAddressProvider LocalAddressProvider, nodeProxyingDisabled bool) *Router {
 	return &Router{
 		localBackend:         localBackend,
 		remoteBackendFactory: backendFactory,
 		localAddressProvider: localAddressProvider,
+		nodeProxyingDisabled: nodeProxyingDisabled,
 	}
 }
 
@@ -44,6 +46,17 @@ func NewRouter(backendFactory RemoteBackendFactory, localBackend proxy.Backend, 
 func (r *Router) Register(*grpc.Server) {}
 
 // Director implements proxy.StreamDirector function.
+//
+// When node proxying is disabled (nodeProxyingDisabled=true), Omni connects
+// directly to each node via SideroLink, so the "node" header should never
+// arrive here — it is rejected. When "nodes" has a single entry, it must be
+// this node itself (Omni routed directly and preserved the header).
+// All "nodes" entries (single or multiple) go through One2Many fan-out via
+// remote backends so that AppendInfo sets Metadata.Hostname in the response.
+//
+// When node proxying is enabled (nodeProxyingDisabled=false, default), requests
+// with "node" are forwarded to a single remote node, and "nodes" triggers
+// fan-out across all listed targets (original Talos apid behavior).
 func (r *Router) Director(ctx context.Context, fullMethodName string) (proxy.Mode, []proxy.Backend, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -54,24 +67,62 @@ func (r *Router) Director(ctx context.Context, fullMethodName string) (proxy.Mod
 		return proxy.One2One, []proxy.Backend{r.localBackend}, nil
 	}
 
+	if r.nodeProxyingDisabled {
+		return r.directAccessDirector(md, fullMethodName)
+	}
+
+	return r.proxyDirector(md, fullMethodName)
+}
+
+// directAccessDirector handles the case where node proxying is disabled.
+// Omni talks to each node directly via SideroLink.
+func (r *Router) directAccessDirector(md metadata.MD, fullMethodName string) (proxy.Mode, []proxy.Backend, error) {
+	if _, exists := md["node"]; exists {
+		return proxy.One2One, nil, status.Error(codes.Unimplemented, "single-node forwarding via 'node' header is not supported")
+	}
+
+	nodes := md["nodes"]
+	if len(nodes) == 0 {
+		return proxy.One2One, []proxy.Backend{r.localBackend}, nil
+	}
+
+	// Single-entry "nodes" means Omni routed directly to this node and preserved
+	// the header so apid sets Metadata.Hostname in the response. Verify it's actually us.
+	if len(nodes) == 1 {
+		if !r.localAddressProvider.IsLocalTarget(nodes[0]) {
+			return proxy.One2One, nil, status.Errorf(codes.InvalidArgument, "single-entry 'nodes' target %q is not this node", nodes[0])
+		}
+	}
+
+	// COSI methods do not support one-2-many proxying.
+	if strings.HasPrefix(fullMethodName, "/cosi.") {
+		return proxy.One2One, nil, status.Error(codes.InvalidArgument, "one-2-many proxying is not supported for COSI methods")
+	}
+
+	// Fan-out through remote backends. Even for single-entry "nodes" pointing to self,
+	// we go through the fan-out path so that the remote backend's AppendInfo sets
+	// Metadata.Hostname in the response (matching real Talos apid behavior).
+	backends := make([]proxy.Backend, len(nodes))
+
+	for i, target := range nodes {
+		var err error
+
+		backends[i], err = r.remoteBackendFactory(target)
+		if err != nil {
+			return proxy.One2Many, nil, status.Error(codes.Internal, err.Error())
+		}
+	}
+
+	return proxy.One2Many, backends, nil
+}
+
+// proxyDirector handles the case where node proxying is enabled (original Talos apid behavior).
+func (r *Router) proxyDirector(md metadata.MD, fullMethodName string) (proxy.Mode, []proxy.Backend, error) {
 	nodes, okNodes := md["nodes"]
 	node, okNode := md["node"]
 
 	if okNode && len(node) != 1 {
 		return proxy.One2One, nil, status.Error(codes.InvalidArgument, "node metadata must be single-valued")
-	}
-
-	// special handling for cases when a single node is requested, but forwarding is disabled
-	//
-	// if there's a single destination, and that destination is local node, skip forwarding and send a request to the same node
-	if r.remoteBackendFactory == nil {
-		if okNode && r.localAddressProvider.IsLocalTarget(node[0]) {
-			okNode = false
-		}
-
-		if okNodes && len(nodes) == 1 && r.localAddressProvider.IsLocalTarget(nodes[0]) {
-			okNodes = false
-		}
 	}
 
 	switch {
@@ -85,17 +136,12 @@ func (r *Router) Director(ctx context.Context, fullMethodName string) (proxy.Mod
 	case okNode:
 		return r.singleDirector(node[0])
 	default:
-		// send directly to local node, skips another layer of proxying
 		return proxy.One2One, []proxy.Backend{r.localBackend}, nil
 	}
 }
 
 // singleDirector sends request to a single instance in one-2-one mode.
 func (r *Router) singleDirector(target string) (proxy.Mode, []proxy.Backend, error) {
-	if r.remoteBackendFactory == nil {
-		return proxy.One2One, nil, status.Error(codes.PermissionDenied, "no request forwarding")
-	}
-
 	backend, err := r.remoteBackendFactory(target)
 	if err != nil {
 		return proxy.One2One, nil, status.Error(codes.Internal, err.Error())
@@ -106,10 +152,6 @@ func (r *Router) singleDirector(target string) (proxy.Mode, []proxy.Backend, err
 
 // aggregateDirector sends request across set of remote instances and aggregates results.
 func (r *Router) aggregateDirector(targets []string) (proxy.Mode, []proxy.Backend, error) {
-	if r.remoteBackendFactory == nil {
-		return proxy.One2One, nil, status.Error(codes.PermissionDenied, "no request forwarding")
-	}
-
 	var err error
 
 	backends := make([]proxy.Backend, len(targets))

--- a/internal/pkg/machine/services/apid/pkg/director/director_test.go
+++ b/internal/pkg/machine/services/apid/pkg/director/director_test.go
@@ -26,15 +26,16 @@ type DirectorSuite struct {
 }
 
 func (suite *DirectorSuite) SetupSuite() {
-	suite.localBackend = &mockBackend{}
+	suite.localBackend = &mockBackend{target: "local"}
 	suite.router = director.NewRouter(
 		mockBackendFactory,
 		suite.localBackend,
 		&mockLocalAddressProvider{
 			local: map[string]struct{}{
-				"localhost": {},
+				"10.0.0.1": {},
 			},
 		},
+		true, // nodeProxyingDisabled
 	)
 }
 
@@ -53,44 +54,6 @@ func (suite *DirectorSuite) TestStreamedDetector() {
 	suite.Assert().False(suite.router.StreamedDetector("/service.Service/getStreamItem"))
 }
 
-func (suite *DirectorSuite) TestDirectorAggregate() {
-	ctx := context.Background()
-
-	md := metadata.New(nil)
-	md.Set("nodes", "127.0.0.1", "127.0.0.2")
-	mode, backends, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(proxy.One2Many, mode)
-	suite.Assert().Len(backends, 2)
-	suite.Assert().Equal("127.0.0.1", backends[0].(*mockBackend).target) //nolint:forcetypeassert,errcheck
-	suite.Assert().Equal("127.0.0.2", backends[1].(*mockBackend).target) //nolint:forcetypeassert,errcheck
-	suite.Assert().NoError(err)
-
-	md = metadata.New(nil)
-	md.Set("nodes", "127.0.0.1")
-	mode, backends, err = suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(proxy.One2Many, mode)
-	suite.Assert().Len(backends, 1)
-	suite.Assert().Equal("127.0.0.1", backends[0].(*mockBackend).target) //nolint:forcetypeassert,errcheck
-	suite.Assert().NoError(err)
-}
-
-func (suite *DirectorSuite) TestDirectorSingleNode() {
-	ctx := context.Background()
-
-	md := metadata.New(nil)
-	md.Set("node", "127.0.0.1")
-	mode, backends, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(proxy.One2One, mode)
-	suite.Assert().Len(backends, 1)
-	suite.Assert().Equal("127.0.0.1", backends[0].(*mockBackend).target) //nolint:forcetypeassert,errcheck
-	suite.Assert().NoError(err)
-
-	md = metadata.New(nil)
-	md.Set("node", "127.0.0.1", "127.0.0.2")
-	_, _, err = suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
-}
-
 func (suite *DirectorSuite) TestDirectorLocal() {
 	ctx := context.Background()
 
@@ -102,59 +65,196 @@ func (suite *DirectorSuite) TestDirectorLocal() {
 	suite.Assert().NoError(err)
 }
 
-func (suite *DirectorSuite) TestDirectorNoRemoteBackend() {
-	// override the router to have no remote backends
-	router := director.NewRouter(
-		nil,
-		suite.localBackend,
-		&mockLocalAddressProvider{
-			local: map[string]struct{}{
-				"localhost": {},
-			},
-		},
-	)
-
-	ctx := context.Background()
-
-	// request forwarding via node/nodes is disabled
-	md := metadata.New(nil)
-	md.Set("node", "127.0.0.1")
-	_, _, err := router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Error(err)
-	suite.Assert().Equal(codes.PermissionDenied, status.Code(err))
-
-	md = metadata.New(nil)
-	md.Set("nodes", "127.0.0.1", "127.0.0.2")
-	_, _, err = router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Error(err)
-	suite.Assert().Equal(codes.PermissionDenied, status.Code(err))
-
-	// no request forwarding, allowed
-	md = metadata.New(nil)
-	mode, backends, err := router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(proxy.One2One, mode)
-	suite.Assert().Len(backends, 1)
-	suite.Assert().Equal(suite.localBackend, backends[0])
-	suite.Assert().NoError(err)
-
-	// request forwarding to local address, allowed
-	md = metadata.New(nil)
-	md.Set("node", "localhost")
-	mode, backends, err = router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
-	suite.Assert().Equal(proxy.One2One, mode)
-	suite.Assert().Len(backends, 1)
-	suite.Assert().Equal(suite.localBackend, backends[0])
-	suite.Assert().NoError(err)
-
-	md = metadata.New(nil)
-	md.Set("nodes", "localhost")
-	mode, backends, err = router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+func (suite *DirectorSuite) TestDirectorNoMetadata() {
+	mode, backends, err := suite.router.Director(context.Background(), "/service.Service/method")
 	suite.Assert().Equal(proxy.One2One, mode)
 	suite.Assert().Len(backends, 1)
 	suite.Assert().Equal(suite.localBackend, backends[0])
 	suite.Assert().NoError(err)
 }
 
+func (suite *DirectorSuite) TestDirectorProxyFrom() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("proxyfrom", "some-node")
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	mode, backends, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+	suite.Assert().Equal(proxy.One2One, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().Equal(suite.localBackend, backends[0])
+	suite.Assert().NoError(err)
+}
+
+func (suite *DirectorSuite) TestDirectorNodeHeaderRejected() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("node", "10.0.0.1")
+	_, _, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.Unimplemented, status.Code(err))
+}
+
+func (suite *DirectorSuite) TestDirectorSingleNodeInNodesLocal() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1")
+	mode, backends, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+	suite.Assert().Equal(proxy.One2Many, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().NoError(err)
+}
+
+func (suite *DirectorSuite) TestDirectorSingleNodeInNodesNotLocal() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.99")
+	_, _, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+}
+
+func (suite *DirectorSuite) TestDirectorMultipleNodes() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	mode, backends, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/service.Service/method")
+	suite.Assert().Equal(proxy.One2Many, mode)
+	suite.Assert().Len(backends, 2)
+	suite.Assert().NoError(err)
+}
+
+func (suite *DirectorSuite) TestDirectorSingleNodeCOSIRejected() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1")
+	_, _, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/cosi.resource.State/List")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+}
+
+func (suite *DirectorSuite) TestDirectorMultipleNodesCOSIRejected() {
+	ctx := context.Background()
+
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	_, _, err := suite.router.Director(metadata.NewIncomingContext(ctx, md), "/cosi.resource.State/List")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+}
+
 func TestDirectorSuite(t *testing.T) {
 	suite.Run(t, new(DirectorSuite))
+}
+
+// ProxyDirectorSuite tests the proxy-enabled mode (original Talos apid behavior).
+type ProxyDirectorSuite struct {
+	suite.Suite
+
+	localBackend *mockBackend
+	router       *director.Router
+}
+
+func (suite *ProxyDirectorSuite) SetupSuite() {
+	suite.localBackend = &mockBackend{target: "local"}
+	suite.router = director.NewRouter(
+		mockBackendFactory,
+		suite.localBackend,
+		&mockLocalAddressProvider{
+			local: map[string]struct{}{
+				"10.0.0.1": {},
+			},
+		},
+		false, // nodeProxyingDisabled
+	)
+}
+
+func (suite *ProxyDirectorSuite) TestNoMetadata() {
+	mode, backends, err := suite.router.Director(context.Background(), "/service.Service/method")
+	suite.Assert().Equal(proxy.One2One, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().Equal(suite.localBackend, backends[0])
+	suite.Assert().NoError(err)
+}
+
+func (suite *ProxyDirectorSuite) TestEmptyMetadata() {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(nil))
+	mode, backends, err := suite.router.Director(ctx, "/service.Service/method")
+	suite.Assert().Equal(proxy.One2One, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().Equal(suite.localBackend, backends[0])
+	suite.Assert().NoError(err)
+}
+
+func (suite *ProxyDirectorSuite) TestProxyFrom() {
+	md := metadata.New(nil)
+	md.Set("proxyfrom", "some-node")
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	mode, backends, err := suite.router.Director(ctx, "/service.Service/method")
+	suite.Assert().Equal(proxy.One2One, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().Equal(suite.localBackend, backends[0])
+	suite.Assert().NoError(err)
+}
+
+func (suite *ProxyDirectorSuite) TestNodeHeaderForwardsToRemote() {
+	md := metadata.New(nil)
+	md.Set("node", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	mode, backends, err := suite.router.Director(ctx, "/service.Service/method")
+	suite.Assert().Equal(proxy.One2One, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().NoError(err)
+	// backend should be the remote one, not local
+	suite.Assert().NotEqual(suite.localBackend, backends[0])
+}
+
+func (suite *ProxyDirectorSuite) TestNodeHeaderMultipleValuesRejected() {
+	md := metadata.New(nil)
+	md.Append("node", "10.0.0.1")
+	md.Append("node", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, _, err := suite.router.Director(ctx, "/service.Service/method")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+}
+
+func (suite *ProxyDirectorSuite) TestSingleNodeInNodesForwardsToRemote() {
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	mode, backends, err := suite.router.Director(ctx, "/service.Service/method")
+	// in proxy mode, single-entry "nodes" still goes through fan-out, no local address check
+	suite.Assert().Equal(proxy.One2Many, mode)
+	suite.Assert().Len(backends, 1)
+	suite.Assert().NoError(err)
+}
+
+func (suite *ProxyDirectorSuite) TestMultipleNodes() {
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	mode, backends, err := suite.router.Director(ctx, "/service.Service/method")
+	suite.Assert().Equal(proxy.One2Many, mode)
+	suite.Assert().Len(backends, 2)
+	suite.Assert().NoError(err)
+}
+
+func (suite *ProxyDirectorSuite) TestMultipleNodesCOSIRejected() {
+	md := metadata.New(nil)
+	md.Set("nodes", "10.0.0.1", "10.0.0.2")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, _, err := suite.router.Director(ctx, "/cosi.resource.State/List")
+	suite.Assert().Error(err)
+	suite.Assert().Equal(codes.InvalidArgument, status.Code(err))
+}
+
+func TestProxyDirectorSuite(t *testing.T) {
+	suite.Run(t, new(ProxyDirectorSuite))
 }

--- a/internal/pkg/machine/services/apid/pkg/director/local_address.go
+++ b/internal/pkg/machine/services/apid/pkg/director/local_address.go
@@ -18,69 +18,76 @@ type LocalAddressProvider interface {
 	IsLocalTarget(string) bool
 }
 
-// localAddressProvider watches and keeps track of the local node addresses.
-type localAddressProvider struct {
+// NewLocalAddressProvider initializes watches and returns a new LocalAddrProvider.
+//
+// Call Run to start processing events.
+func NewLocalAddressProvider(st state.State) (*LocalAddrProvider, error) {
+	return &LocalAddrProvider{state: st}, nil
+}
+
+// LocalAddrProvider watches and keeps track of the local node addresses.
+type LocalAddrProvider struct {
+	state          state.State
 	localAddresses map[string]struct{}
 	localHostnames map[string]struct{}
-
-	mu sync.Mutex
+	mu             sync.Mutex
 }
 
-// NewLocalAddressProvider initializes and returns a new LocalAddressProvider.
-func NewLocalAddressProvider(ctx context.Context, st state.State) (LocalAddressProvider, error) {
-	p := &localAddressProvider{}
+// Run processes watch events until the context is canceled.
+func (p *LocalAddrProvider) Run(ctx context.Context) error {
+	eventCh := make(chan state.Event)
 
-	evCh := make(chan state.Event)
-
-	if err := st.Watch(ctx, resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.NodeAddressCurrentID, resource.VersionUndefined), evCh); err != nil {
-		return nil, err
+	if err := p.state.Watch(ctx, resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.NodeAddressCurrentID, resource.VersionUndefined), eventCh); err != nil {
+		return err
 	}
 
-	if err := st.Watch(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined), evCh); err != nil {
-		return nil, err
+	if err := p.state.Watch(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined), eventCh); err != nil {
+		return err
 	}
 
-	go p.watch(evCh)
-
-	return p, nil
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-eventCh:
+			p.handleEvent(ev)
+		}
+	}
 }
 
-func (p *localAddressProvider) watch(evCh <-chan state.Event) {
-	for ev := range evCh {
-		switch ev.Type {
-		case state.Created, state.Updated, state.Noop:
-			// expected
-		case state.Destroyed, state.Bootstrapped, state.Errored:
-			// shouldn't happen, ignore
-			continue
+func (p *LocalAddrProvider) handleEvent(ev state.Event) {
+	switch ev.Type {
+	case state.Created, state.Updated, state.Noop:
+		// expected
+	case state.Destroyed, state.Bootstrapped, state.Errored:
+		return
+	}
+
+	switch r := ev.Resource.(type) {
+	case *network.NodeAddress:
+		p.mu.Lock()
+
+		p.localAddresses = make(map[string]struct{}, len(r.TypedSpec().Addresses))
+
+		for _, addr := range r.TypedSpec().Addresses {
+			p.localAddresses[addr.Addr().String()] = struct{}{}
 		}
 
-		switch r := ev.Resource.(type) {
-		case *network.NodeAddress:
-			p.mu.Lock()
+		p.mu.Unlock()
+	case *network.HostnameStatus:
+		p.mu.Lock()
 
-			p.localAddresses = make(map[string]struct{}, len(r.TypedSpec().Addresses))
+		p.localHostnames = make(map[string]struct{}, 2)
 
-			for _, addr := range r.TypedSpec().Addresses {
-				p.localAddresses[addr.Addr().String()] = struct{}{}
-			}
+		p.localHostnames[r.TypedSpec().Hostname] = struct{}{}
+		p.localHostnames[r.TypedSpec().FQDN()] = struct{}{}
 
-			p.mu.Unlock()
-		case *network.HostnameStatus:
-			p.mu.Lock()
-
-			p.localHostnames = make(map[string]struct{}, 2)
-
-			p.localHostnames[r.TypedSpec().Hostname] = struct{}{}
-			p.localHostnames[r.TypedSpec().FQDN()] = struct{}{}
-
-			p.mu.Unlock()
-		}
+		p.mu.Unlock()
 	}
 }
 
 // IsLocalTarget returns true if the address (hostname) is local.
-func (p *localAddressProvider) IsLocalTarget(target string) bool {
+func (p *LocalAddrProvider) IsLocalTarget(target string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/pkg/provider/controllers/machine/machine.go
+++ b/internal/pkg/provider/controllers/machine/machine.go
@@ -23,12 +23,13 @@ import (
 type TaskSpec struct {
 	_ [0]func() // make uncomparable
 
-	Machine          *resources.MachineTask
-	GlobalState      state.State
-	SchematicService *schematic.Service
-	Params           *machine.SideroLinkParams
-	Kubernetes       *kubefactory.Kubernetes
-	NC               *network.Client
+	Machine              *resources.MachineTask
+	GlobalState          state.State
+	SchematicService     *schematic.Service
+	Params               *machine.SideroLinkParams
+	Kubernetes           *kubefactory.Kubernetes
+	NC                   *network.Client
+	NodeProxyingDisabled bool
 }
 
 // ID implements task.TaskSpec.
@@ -59,5 +60,6 @@ func (s TaskSpec) RunTask(ctx context.Context, logger *zap.Logger, _ any) error 
 		machine.WithSchematic(s.Machine.TypedSpec().Value.Schematic),
 		machine.WithNetworkClient(s.NC),
 		machine.WithSecureBoot(s.Machine.TypedSpec().Value.SecureBoot),
+		machine.WithNodeProxyingDisabled(s.NodeProxyingDisabled),
 	)
 }

--- a/internal/pkg/provider/controllers/machine_runner.go
+++ b/internal/pkg/provider/controllers/machine_runner.go
@@ -29,21 +29,23 @@ import (
 
 // MachineController runs a machine for each machine request.
 type MachineController struct {
-	runner           *task.Runner[any, machinetask.TaskSpec]
-	kubernetes       *kubefactory.Kubernetes
-	nc               *network.Client
-	globalState      state.State
-	schematicService *schematic.Service
+	runner               *task.Runner[any, machinetask.TaskSpec]
+	kubernetes           *kubefactory.Kubernetes
+	nc                   *network.Client
+	globalState          state.State
+	schematicService     *schematic.Service
+	nodeProxyingDisabled bool
 }
 
 // NewMachineController creates new machine controller.
-func NewMachineController(globalState state.State, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service) *MachineController {
+func NewMachineController(globalState state.State, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service, nodeProxyingDisabled bool) *MachineController {
 	return &MachineController{
-		runner:           task.NewEqualRunner[machinetask.TaskSpec](),
-		globalState:      globalState,
-		kubernetes:       kubernetes,
-		nc:               nc,
-		schematicService: schematicService,
+		runner:               task.NewEqualRunner[machinetask.TaskSpec](),
+		globalState:          globalState,
+		kubernetes:           kubernetes,
+		nc:                   nc,
+		schematicService:     schematicService,
+		nodeProxyingDisabled: nodeProxyingDisabled,
 	}
 }
 
@@ -113,12 +115,13 @@ func (ctrl *MachineController) Run(ctx context.Context, r controller.Runtime, lo
 			}
 
 			ctrl.runner.StartTask(ctx, logger, m.Metadata().ID(), machinetask.TaskSpec{
-				Machine:          m,
-				GlobalState:      ctrl.globalState,
-				SchematicService: ctrl.schematicService,
-				Kubernetes:       ctrl.kubernetes,
-				Params:           params,
-				NC:               ctrl.nc,
+				Machine:              m,
+				GlobalState:          ctrl.globalState,
+				SchematicService:     ctrl.schematicService,
+				Kubernetes:           ctrl.kubernetes,
+				Params:               params,
+				NC:                   ctrl.nc,
+				NodeProxyingDisabled: ctrl.nodeProxyingDisabled,
 			}, nil)
 
 			touchedIDs[m.Metadata().ID()] = struct{}{}

--- a/internal/pkg/provider/provider.go
+++ b/internal/pkg/provider/provider.go
@@ -16,9 +16,9 @@ import (
 )
 
 // RegisterControllers registers additional controllers required for the infra provider.
-func RegisterControllers(runtime *emu.Runtime, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service) error {
+func RegisterControllers(runtime *emu.Runtime, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service, nodeProxyingDisabled bool) error {
 	controllers := []controller.Controller{
-		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService),
+		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService, nodeProxyingDisabled),
 	}
 
 	for _, ctrl := range controllers {


### PR DESCRIPTION
Add a flag to control whether apid allows node-to-node proxying. When enabled, the director rejects the `node` header, validates that a single-entry `nodes` header targets this node, and still proxies multi-node `nodes` requests via One2Many fan-out. When disabled (default), the original Talos apid behavior is preserved: `node` forwards to a single remote, `nodes` triggers fan-out across all listed targets.

The flag is wired through both `talemu` and `talemu-infra-provider` entrypoints and plumbed down to the director via the existing options chain.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>