### PR TITLE
feat: emulate maintenance install/upgrade and boot id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/akutz/memconn v0.1.0
 	github.com/cosi-project/runtime v1.16.1
 	github.com/go-logr/zapr v1.3.0
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jsimonetti/rtnetlink v1.4.2
@@ -140,7 +141,6 @@ require (
 	github.com/google/cel-go v0.28.1 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/internal/pkg/machine/services/apid.go
+++ b/internal/pkg/machine/services/apid.go
@@ -50,6 +50,7 @@ type APID struct {
 	localAddressProvider director.LocalAddressProvider
 	shutdown             chan struct{}
 	eg                   *errgroup.Group
+	sharedMachineState   *machineState
 	machineID            string
 	imageFactoryHost     string
 	nodeProxyingDisabled bool
@@ -64,6 +65,7 @@ func NewAPID(machineID string, state state.State, globalState state.State, image
 		imageFactoryHost:     imageFactoryHost,
 		localAddressProvider: localAddressProvider,
 		nodeProxyingDisabled: nodeProxyingDisabled,
+		sharedMachineState:   newMachineState(),
 	}
 }
 
@@ -131,6 +133,10 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 		"/machine.MachineService/Logs",
 		"/machine.MachineService/PacketCapture",
 		"/machine.MachineService/Read",
+		"/machine.ImageService/List",
+		"/machine.ImageService/Pull",
+		"/machine.LifecycleService/Install",
+		"/machine.LifecycleService/Upgrade",
 		"/os.OSService/Dmesg",
 		"/cluster.ClusterService/HealthCheck",
 	} {
@@ -163,7 +169,9 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	}
 
 	recoveryOption := recovery.WithRecoveryHandler(recoveryHandler)
-	machineSrv := NewMachineService(apid.machineID, apid.state, apid.globalState, apid.imageFactoryHost, logger)
+	machineSrv := NewMachineService(apid.machineID, apid.state, apid.globalState, apid.imageFactoryHost, logger, apid.sharedMachineState)
+	imageSrv := NewImageService(apid.state, logger)
+	lifecycleSrv := NewLifecycleService(apid.state, apid.imageFactoryHost, logger, apid.sharedMachineState)
 	localServer := grpc.NewServer(
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.ForceServerCodecV2(proxy.Codec()),
@@ -173,6 +181,8 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	)
 
 	machine.RegisterMachineServiceServer(localServer, machineSrv)
+	machine.RegisterImageServiceServer(localServer, imageSrv)
+	machine.RegisterLifecycleServiceServer(localServer, lifecycleSrv)
 	storage.RegisterStorageServiceServer(localServer, machineSrv)
 	cosiv1alpha1.RegisterStateServer(localServer, resourceState)
 

--- a/internal/pkg/machine/services/image.go
+++ b/internal/pkg/machine/services/image.go
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services
+
+import (
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+// ImageService emulates Talos's image service.
+type ImageService struct {
+	machine.UnimplementedImageServiceServer
+
+	state  state.State
+	logger *zap.Logger
+}
+
+// NewImageService creates a new ImageService.
+func NewImageService(st state.State, logger *zap.Logger) *ImageService {
+	return &ImageService{state: st, logger: logger}
+}
+
+// Pull implements machine.ImageServiceServer.
+func (s *ImageService) Pull(req *machine.ImageServicePullRequest, srv machine.ImageService_PullServer) error {
+	ref := req.GetImageRef()
+	if ref == "" {
+		return status.Error(codes.InvalidArgument, "image reference is required")
+	}
+
+	digest, err := cacheImage(srv.Context(), s.state, ref)
+	if err != nil {
+		return err
+	}
+
+	return srv.Send(&machine.ImageServicePullResponse{
+		Response: &machine.ImageServicePullResponse_Name{Name: pinImageReference(ref, digest)},
+	})
+}
+
+// List implements machine.ImageServiceServer.
+func (s *ImageService) List(_ *machine.ImageServiceListRequest, srv machine.ImageService_ListServer) error {
+	images, err := safe.ReaderListAll[*talos.CachedImage](srv.Context(), s.state)
+	if err != nil {
+		return err
+	}
+
+	return images.ForEachErr(func(r *talos.CachedImage) error {
+		return srv.Send(&machine.ImageServiceListResponse{
+			Name:      r.Metadata().ID(),
+			Digest:    r.TypedSpec().Value.Digest,
+			Size:      r.TypedSpec().Value.Size,
+			CreatedAt: timestamppb.New(r.Metadata().Created()),
+		})
+	})
+}
+
+// pinImageReference pins the reference to its digest as name:tag@digest, keeping the tag so setImage
+// can still recover the version. An already-pinned reference is returned unchanged.
+func pinImageReference(ref, digest string) string {
+	if strings.Contains(ref, "@") {
+		return ref
+	}
+
+	return ref + "@" + digest
+}

--- a/internal/pkg/machine/services/image_test.go
+++ b/internal/pkg/machine/services/image_test.go
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+	"github.com/siderolabs/talemu/internal/pkg/machine/services"
+)
+
+func newImageService(t *testing.T) (*services.ImageService, state.State) {
+	t.Helper()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	return services.NewImageService(st, zaptest.NewLogger(t)), st
+}
+
+func TestImagePull(t *testing.T) {
+	const ref = "factory.talos.dev/installer/abc123:v1.14.0"
+
+	svc, st := newImageService(t)
+
+	srv := &recordingStream[*machine.ImageServicePullResponse]{ctx: t.Context()}
+	require.NoError(t, svc.Pull(&machine.ImageServicePullRequest{ImageRef: ref}, srv))
+
+	// Pull returns the reference pinned to its digest, keeping the tag (canonical name:tag@digest).
+	require.Len(t, srv.sent, 1)
+	name := srv.sent[0].GetName()
+	require.True(t, strings.HasPrefix(name, "factory.talos.dev/installer/abc123:v1.14.0@sha256:"), "got %q", name)
+
+	// The pulled image is recorded so image list calls can observe it.
+	cached, err := safe.ReaderGetByID[*talos.CachedImage](t.Context(), st, ref)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(cached.TypedSpec().Value.Digest, "sha256:"))
+}
+
+func TestImageList(t *testing.T) {
+	const ref = "factory.talos.dev/installer/abc123:v1.14.0"
+
+	svc, _ := newImageService(t)
+
+	// Nothing pulled yet.
+	empty := &recordingStream[*machine.ImageServiceListResponse]{ctx: t.Context()}
+	require.NoError(t, svc.List(&machine.ImageServiceListRequest{}, empty))
+	require.Empty(t, empty.sent)
+
+	require.NoError(t, svc.Pull(&machine.ImageServicePullRequest{ImageRef: ref}, &recordingStream[*machine.ImageServicePullResponse]{ctx: t.Context()}))
+
+	// The pulled image now shows up in the list.
+	srv := &recordingStream[*machine.ImageServiceListResponse]{ctx: t.Context()}
+	require.NoError(t, svc.List(&machine.ImageServiceListRequest{}, srv))
+	require.Len(t, srv.sent, 1)
+	require.Equal(t, ref, srv.sent[0].GetName())
+	require.True(t, strings.HasPrefix(srv.sent[0].GetDigest(), "sha256:"))
+}
+
+func TestImagePullNotFound(t *testing.T) {
+	svc, _ := newImageService(t)
+
+	err := svc.Pull(&machine.ImageServicePullRequest{ImageRef: "factory.talos.dev/installer/abc123:v1.14.0-bad"}, &recordingStream[*machine.ImageServicePullResponse]{ctx: t.Context()})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestMachineImagePullNotFound asserts the legacy MachineService.ImagePull rejects a "-bad" image
+// with the same NotFound code as ImageService.Pull, since both share the cacheImage pull path.
+func TestMachineImagePullNotFound(t *testing.T) {
+	svc := newMachineService(t)
+
+	_, err := svc.ImagePull(t.Context(), &machine.ImagePullRequest{Reference: "factory.talos.dev/installer/abc123:v1.14.0-bad"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestImagePullEmptyRef(t *testing.T) {
+	svc, _ := newImageService(t)
+
+	err := svc.Pull(&machine.ImageServicePullRequest{ImageRef: ""}, &recordingStream[*machine.ImageServicePullResponse]{ctx: t.Context()})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/internal/pkg/machine/services/lifecycle.go
+++ b/internal/pkg/machine/services/lifecycle.go
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// LifecycleService is a GRPC service emulating the behavior of the Talos lifecycle service.
+type LifecycleService struct {
+	machine.UnimplementedLifecycleServiceServer
+
+	state              state.State
+	logger             *zap.Logger
+	sharedMachineState *machineState
+	imageFactoryHost   string
+}
+
+// NewLifecycleService creates a new LifecycleService.
+func NewLifecycleService(st state.State, imageFactoryHost string, logger *zap.Logger, sharedMachineState *machineState) *LifecycleService {
+	if sharedMachineState == nil {
+		sharedMachineState = newMachineState()
+	}
+
+	return &LifecycleService{state: st, imageFactoryHost: imageFactoryHost, logger: logger, sharedMachineState: sharedMachineState}
+}
+
+// Install implements machine.LifecycleServiceServer.
+func (s *LifecycleService) Install(req *machine.LifecycleServiceInstallRequest, srv machine.LifecycleService_InstallServer) error {
+	ctx := srv.Context()
+
+	if !s.sharedMachineState.lifecycleMu.TryLock() {
+		return errLifecycleInProgress
+	}
+	defer s.sharedMachineState.lifecycleMu.Unlock()
+
+	image := req.GetSource().GetImageName()
+	if image == "" {
+		return status.Error(codes.InvalidArgument, "install image name is required")
+	}
+
+	disk := req.GetDestination().GetDisk()
+	if disk == "" {
+		return status.Error(codes.InvalidArgument, "install destination disk is required")
+	}
+
+	if err := validateInstaller(ctx, s.state, image); err != nil {
+		return err
+	}
+
+	installed, err := machineInstalled(ctx, s.state)
+	if err != nil {
+		return err
+	}
+
+	if installed {
+		return status.Error(codes.AlreadyExists, "Talos is already installed on disk")
+	}
+
+	if _, err = setImage(ctx, s.state, s.imageFactoryHost, image); err != nil {
+		return err
+	}
+
+	if err = s.state.Modify(ctx, block.NewSystemDisk(block.NamespaceName, block.SystemDiskID), func(res resource.Resource) error {
+		typedRes := res.(*block.SystemDisk) //nolint:forcetypeassert,errcheck
+		typedRes.TypedSpec().DiskID = filepath.Base(disk)
+		typedRes.TypedSpec().DevPath = disk
+
+		return nil
+	}, state.WithUpdateOwner("runtime.MachineStatusController")); err != nil {
+		return err
+	}
+
+	return streamInstallerProgress(
+		func(p *machine.LifecycleServiceInstallProgress) error {
+			return srv.Send(&machine.LifecycleServiceInstallResponse{Progress: p})
+		},
+		fmt.Sprintf("[talemu] installing %s to %s", image, disk),
+		"[talemu] writing system partitions",
+		"[talemu] installation complete",
+	)
+}
+
+// Upgrade implements machine.LifecycleServiceServer.
+func (s *LifecycleService) Upgrade(req *machine.LifecycleServiceUpgradeRequest, srv machine.LifecycleService_UpgradeServer) error {
+	ctx := srv.Context()
+
+	if !s.sharedMachineState.lifecycleMu.TryLock() {
+		return errLifecycleInProgress
+	}
+	defer s.sharedMachineState.lifecycleMu.Unlock()
+
+	image := req.GetSource().GetImageName()
+	if image == "" {
+		return status.Error(codes.InvalidArgument, "upgrade image name is required")
+	}
+
+	if err := validateInstaller(ctx, s.state, image); err != nil {
+		return err
+	}
+
+	installed, err := machineInstalled(ctx, s.state)
+	if err != nil {
+		return err
+	}
+
+	if !installed {
+		return status.Error(codes.FailedPrecondition, "Talos is not installed on disk")
+	}
+
+	if _, err = setImage(ctx, s.state, s.imageFactoryHost, image); err != nil {
+		return err
+	}
+
+	return streamInstallerProgress(
+		func(p *machine.LifecycleServiceInstallProgress) error {
+			return srv.Send(&machine.LifecycleServiceUpgradeResponse{Progress: p})
+		},
+		fmt.Sprintf("[talemu] upgrading to %s", image),
+		"[talemu] writing new system image",
+		"[talemu] upgrade complete",
+	)
+}
+
+// machineInstalled reports whether Talos is installed on disk, modeled by the presence of the SystemDisk resource.
+func machineInstalled(ctx context.Context, st state.State) (bool, error) {
+	_, err := safe.ReaderGetByID[*block.SystemDisk](ctx, st, block.SystemDiskID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+func streamInstallerProgress(send func(*machine.LifecycleServiceInstallProgress) error, messages ...string) error {
+	for _, msg := range messages {
+		if err := send(installProgressMessage(msg)); err != nil {
+			return err
+		}
+	}
+
+	return send(installProgressExitCode(0))
+}
+
+func installProgressMessage(msg string) *machine.LifecycleServiceInstallProgress {
+	return &machine.LifecycleServiceInstallProgress{
+		Response: &machine.LifecycleServiceInstallProgress_Message{Message: msg},
+	}
+}
+
+func installProgressExitCode(code int32) *machine.LifecycleServiceInstallProgress {
+	return &machine.LifecycleServiceInstallProgress{
+		Response: &machine.LifecycleServiceInstallProgress_ExitCode{ExitCode: code},
+	}
+}

--- a/internal/pkg/machine/services/lifecycle_test.go
+++ b/internal/pkg/machine/services/lifecycle_test.go
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/services"
+)
+
+const (
+	factoryHost    = "factory.talos.dev"
+	lifecycleImage = "factory.talos.dev/installer/abc123:v1.14.0"
+)
+
+// blockingInstallServer blocks inside the first Send until released, keeping the install in flight.
+type blockingInstallServer struct {
+	grpc.ServerStream
+
+	ctx     context.Context //nolint:containedctx
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingInstallServer) Context() context.Context { return b.ctx }
+
+func (b *blockingInstallServer) Send(*machine.LifecycleServiceInstallResponse) error {
+	b.once.Do(func() {
+		close(b.started)
+		<-b.release
+	})
+
+	return nil
+}
+
+// newLifecycleState builds an in-memory state seeded with the SecurityState resource that
+// validateInstaller requires.
+func newLifecycleState(t *testing.T, secureBoot bool) state.State {
+	t.Helper()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	securityState := runtime.NewSecurityStateSpec(runtime.NamespaceName)
+	securityState.TypedSpec().SecureBoot = secureBoot
+
+	require.NoError(t, st.Create(t.Context(), securityState))
+
+	return st
+}
+
+func installRequest(disk string) *machine.LifecycleServiceInstallRequest {
+	return &machine.LifecycleServiceInstallRequest{
+		Source:      &machine.InstallArtifactsSource{ImageName: lifecycleImage},
+		Destination: &machine.InstallDestination{Disk: disk},
+	}
+}
+
+func TestLifecycleInstall(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	srv := &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()}
+	require.NoError(t, svc.Install(installRequest("/dev/sda"), srv))
+
+	// progress messages terminated by an exit code of 0.
+	require.NotEmpty(t, srv.sent)
+	require.NotEmpty(t, srv.sent[0].GetProgress().GetMessage())
+	require.Equal(t, int32(0), srv.sent[len(srv.sent)-1].GetProgress().GetExitCode())
+
+	systemDisk, err := safe.ReaderGetByID[*block.SystemDisk](t.Context(), st, block.SystemDiskID)
+	require.NoError(t, err)
+	require.Equal(t, "sda", systemDisk.TypedSpec().DiskID)
+}
+
+func TestLifecycleInstallEmptyImage(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	err := svc.Install(&machine.LifecycleServiceInstallRequest{
+		Source:      &machine.InstallArtifactsSource{ImageName: ""},
+		Destination: &machine.InstallDestination{Disk: "/dev/sda"},
+	}, &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLifecycleInstallEmptyDisk(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	err := svc.Install(installRequest(""), &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLifecycleInstallAlreadyInstalled(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	require.NoError(t, svc.Install(installRequest("/dev/sda"), &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()}))
+
+	err := svc.Install(installRequest("/dev/sda"), &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()})
+	require.Equal(t, codes.AlreadyExists, status.Code(err))
+}
+
+func TestLifecycleInstallSecureBootRejectsNonSecurebootImage(t *testing.T) {
+	st := newLifecycleState(t, true)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	err := svc.Install(installRequest("/dev/sda"), &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLifecycleUpgradeNotInstalled(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	err := svc.Upgrade(&machine.LifecycleServiceUpgradeRequest{
+		Source: &machine.InstallArtifactsSource{ImageName: lifecycleImage},
+	}, &recordingStream[*machine.LifecycleServiceUpgradeResponse]{ctx: t.Context()})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestLifecycleUpgrade(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	require.NoError(t, svc.Install(installRequest("/dev/sda"), &recordingStream[*machine.LifecycleServiceInstallResponse]{ctx: t.Context()}))
+
+	srv := &recordingStream[*machine.LifecycleServiceUpgradeResponse]{ctx: t.Context()}
+	err := svc.Upgrade(&machine.LifecycleServiceUpgradeRequest{
+		Source: &machine.InstallArtifactsSource{ImageName: "factory.talos.dev/installer/abc123:v1.14.1"},
+	}, srv)
+	require.NoError(t, err)
+
+	// progress messages terminated by an exit code of 0.
+	require.NotEmpty(t, srv.sent)
+	require.NotEmpty(t, srv.sent[0].GetProgress().GetMessage())
+	require.Equal(t, int32(0), srv.sent[len(srv.sent)-1].GetProgress().GetExitCode())
+}
+
+func TestLifecycleConcurrentOperationRejected(t *testing.T) {
+	st := newLifecycleState(t, false)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	blocking := &blockingInstallServer{
+		ctx:     t.Context(),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	done := make(chan error, 1)
+
+	go func() { done <- svc.Install(installRequest("/dev/sda"), blocking) }()
+
+	<-blocking.started // the install is now in flight, holding the lock.
+
+	err := svc.Upgrade(&machine.LifecycleServiceUpgradeRequest{
+		Source: &machine.InstallArtifactsSource{ImageName: lifecycleImage},
+	}, &recordingStream[*machine.LifecycleServiceUpgradeResponse]{ctx: t.Context()})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.ErrorContains(t, err, "already in progress")
+
+	close(blocking.release)
+	require.NoError(t, <-done)
+}
+
+func TestLifecycleUpgradeSecureBootRejectsNonSecurebootImage(t *testing.T) {
+	st := newLifecycleState(t, true)
+	svc := services.NewLifecycleService(st, factoryHost, zaptest.NewLogger(t), nil)
+
+	err := svc.Upgrade(&machine.LifecycleServiceUpgradeRequest{
+		Source: &machine.InstallArtifactsSource{ImageName: lifecycleImage},
+	}, &recordingStream[*machine.LifecycleServiceUpgradeResponse]{ctx: t.Context()})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/internal/pkg/machine/services/machined.go
+++ b/internal/pkg/machine/services/machined.go
@@ -6,16 +6,19 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller/generic"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/google/uuid"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -45,26 +48,30 @@ import (
 type MachineService struct {
 	machine.UnimplementedMachineServiceServer
 	storage.UnimplementedStorageServiceServer
-
-	state       state.State
-	globalState state.State
-
-	logger    *zap.Logger
-	startTime time.Time
-
-	machineID        string
-	imageFactoryHost string
+	startTime          time.Time
+	state              state.State
+	globalState        state.State
+	logger             *zap.Logger
+	sharedMachineState *machineState
+	machineID          string
+	imageFactoryHost   string
 }
 
-// NewMachineService creates a new MachineService.
-func NewMachineService(machineID string, state, globalState state.State, imageFactoryHost string, logger *zap.Logger) *MachineService {
+// NewMachineService creates a new MachineService. sharedMachineState is the per-machine emulator state held
+// across apid restarts; when nil (e.g. in tests) a fresh one is allocated.
+func NewMachineService(machineID string, state, globalState state.State, imageFactoryHost string, logger *zap.Logger, sharedMachineState *machineState) *MachineService {
+	if sharedMachineState == nil {
+		sharedMachineState = newMachineState()
+	}
+
 	return &MachineService{
-		state:            state,
-		globalState:      globalState,
-		logger:           logger,
-		machineID:        machineID,
-		imageFactoryHost: imageFactoryHost,
-		startTime:        time.Now(),
+		state:              state,
+		globalState:        globalState,
+		logger:             logger,
+		machineID:          machineID,
+		imageFactoryHost:   imageFactoryHost,
+		startTime:          time.Now(),
+		sharedMachineState: sharedMachineState,
 	}
 }
 
@@ -79,7 +86,7 @@ func (c *MachineService) ApplyConfiguration(ctx context.Context, request *machin
 	isPartialConfig := cfg.Config().Machine() == nil
 
 	if !isPartialConfig {
-		if err = c.validateInstaller(ctx, cfg.Config().Machine().Install().Image()); err != nil {
+		if err = validateInstaller(ctx, c.state, cfg.Config().Machine().Install().Image()); err != nil {
 			return nil, err
 		}
 	}
@@ -318,47 +325,33 @@ func (c *MachineService) Version(ctx context.Context, _ *emptypb.Empty) (*machin
 
 // Upgrade implements machine.MachineServiceServer.
 func (c *MachineService) Upgrade(ctx context.Context, req *machine.UpgradeRequest) (*machine.UpgradeResponse, error) {
-	if err := c.validateInstaller(ctx, req.Image); err != nil {
+	if !c.sharedMachineState.sequenceMu.TryLock() {
+		return nil, errSequenceInProgress
+	}
+	defer c.sharedMachineState.sequenceMu.Unlock()
+
+	installed, err := machineInstalled(ctx, c.state)
+	if err != nil {
 		return nil, err
 	}
 
-	parts := strings.Split(req.Image, "/")
-
-	var schematic string
-
-	s, version, found := strings.Cut(parts[len(parts)-1], ":")
-	if !found {
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse the image")
+	if !installed {
+		return nil, status.Error(codes.FailedPrecondition, "Talos is not installed")
 	}
 
-	if parts[0] == c.imageFactoryHost {
-		schematic = s
+	if err = validateInstaller(ctx, c.state, req.Image); err != nil {
+		return nil, err
 	}
 
-	image := talos.NewImage(talos.NamespaceName, talos.ImageID)
-	image.TypedSpec().Value.Schematic = schematic
-	image.TypedSpec().Value.Version = version
-
-	changed := true
-
-	if err := c.state.Create(ctx, image); err != nil {
-		if !state.IsConflictError(err) {
-			return nil, err
-		}
-
-		if _, err = safe.StateUpdateWithConflicts(ctx, c.state, image.Metadata(), func(res *talos.Image) error {
-			changed = !res.TypedSpec().Value.EqualVT(image.TypedSpec().Value)
-
-			res.TypedSpec().Value = image.TypedSpec().Value
-
-			return nil
-		}); err != nil {
-			return nil, err
-		}
+	changed, err := setImage(ctx, c.state, c.imageFactoryHost, req.Image)
+	if err != nil {
+		return nil, err
 	}
 
+	// Only reboot when the target image actually differs, so a redundant upgrade (e.g. an Omni
+	// retry to the running version) does not needlessly drop the apid connection.
 	if changed {
-		if _, err := c.Reboot(ctx, &machine.RebootRequest{}); err != nil {
+		if err := c.requestReboot(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -375,15 +368,12 @@ func (c *MachineService) Upgrade(ctx context.Context, req *machine.UpgradeReques
 
 // Reboot implements machine.MachineServiceServer.
 func (c *MachineService) Reboot(ctx context.Context, _ *machine.RebootRequest) (*machine.RebootResponse, error) {
-	reboot := talos.NewReboot(talos.NamespaceName, talos.RebootID)
-	reboot.TypedSpec().Value.Downtime = durationpb.New(time.Second * 2)
-
-	err := destroyResourceByID[*talos.Reboot](ctx, c.state, talos.RebootID)
-	if err != nil && !state.IsNotFoundError(err) {
-		return nil, err
+	if !c.sharedMachineState.sequenceMu.TryLock() {
+		return nil, errSequenceInProgress
 	}
+	defer c.sharedMachineState.sequenceMu.Unlock()
 
-	if err = c.state.Create(ctx, reboot); err != nil {
+	if err := c.requestReboot(ctx); err != nil {
 		return nil, err
 	}
 
@@ -393,6 +383,18 @@ func (c *MachineService) Reboot(ctx context.Context, _ *machine.RebootRequest) (
 		},
 	}, nil
 }
+
+// Read implements machine.MachineServiceServer. The emulator only serves the kernel boot ID file.
+func (c *MachineService) Read(req *machine.ReadRequest, srv machine.MachineService_ReadServer) error {
+	if req.GetPath() != BootIDPath {
+		return status.Errorf(codes.Unimplemented, "reading %q is not supported by the emulator", req.GetPath())
+	}
+
+	return srv.Send(&common.Data{Bytes: []byte(c.currentBootID() + "\n")})
+}
+
+// BootIDPath is the kernel-provided per-boot identifier; its value changes on every reboot.
+const BootIDPath = "/proc/sys/kernel/random/boot_id"
 
 // EtcdMemberList implements machine.MachineServiceServer.
 func (c *MachineService) EtcdMemberList(ctx context.Context, _ *machine.EtcdMemberListRequest) (*machine.EtcdMemberListResponse, error) {
@@ -750,21 +752,33 @@ func (c *MachineService) ImageList(_ *machine.ImageListRequest, serv machine.Mac
 
 // ImagePull implements machine.MachineServiceServer.
 func (c *MachineService) ImagePull(ctx context.Context, req *machine.ImagePullRequest) (*machine.ImagePullResponse, error) {
-	if strings.HasSuffix(req.Reference, "-bad") {
-		return nil, fmt.Errorf("emulator is set to fail on images ending with -bad suffix")
-	}
-
-	image := talos.NewCachedImage(talos.NamespaceName, req.Reference)
-	image.TypedSpec().Value.Digest = "aaaa"
-	image.TypedSpec().Value.Size = 1024
-
-	if err := c.state.Create(ctx, image); err != nil && !state.IsConflictError(err) {
+	if _, err := cacheImage(ctx, c.state, req.Reference); err != nil {
 		return nil, err
 	}
 
 	return &machine.ImagePullResponse{
 		Messages: []*machine.ImagePull{},
 	}, nil
+}
+
+// cacheImage records a pulled image as a CachedImage and returns its digest, derived from the reference so it is stable across calls.
+func cacheImage(ctx context.Context, st state.State, ref string) (string, error) {
+	// The emulator fails on a "-bad" suffix, mapped to the not-found code Talos returns for a missing image, so both pull entry points reject it consistently.
+	if strings.HasSuffix(ref, "-bad") {
+		return "", status.Errorf(codes.NotFound, "image %q not found", ref)
+	}
+
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(ref)))
+
+	image := talos.NewCachedImage(talos.NamespaceName, ref)
+	image.TypedSpec().Value.Digest = digest
+	image.TypedSpec().Value.Size = 1024
+
+	if err := st.Create(ctx, image); err != nil && !state.IsConflictError(err) {
+		return "", err
+	}
+
+	return digest, nil
 }
 
 // Dmesg implements machine.MachineServiceServer.
@@ -850,8 +864,8 @@ func (c *MachineService) MetaDelete(ctx context.Context, req *machine.MetaDelete
 	return &machine.MetaDeleteResponse{}, nil
 }
 
-func (c *MachineService) validateInstaller(ctx context.Context, image string) error {
-	securityState, err := safe.ReaderGetByID[*runtime.SecurityState](ctx, c.state, runtime.SecurityStateID)
+func validateInstaller(ctx context.Context, st state.State, image string) error {
+	securityState, err := safe.ReaderGetByID[*runtime.SecurityState](ctx, st, runtime.SecurityStateID)
 	if err != nil {
 		return err
 	}
@@ -1005,6 +1019,122 @@ func (c *MachineService) Processes(_ context.Context, _ *emptypb.Empty) (*machin
 			{Processes: processes},
 		},
 	}, nil
+}
+
+// setImage records the target Talos image on the machine and reports whether it differs from the image already recorded, so callers can avoid a needless reboot on a redundant upgrade.
+func setImage(ctx context.Context, st state.State, imageFactoryHost, imageRef string) (bool, error) {
+	ref := imageRef
+
+	if at := strings.IndexByte(ref, '@'); at != -1 {
+		ref = ref[:at]
+	}
+
+	parts := strings.Split(ref, "/")
+
+	s, version, found := strings.Cut(parts[len(parts)-1], ":")
+	if !found {
+		return false, status.Errorf(codes.InvalidArgument, "failed to parse the image %q", imageRef)
+	}
+
+	var schematic string
+
+	if parts[0] == imageFactoryHost {
+		schematic = s
+	}
+
+	var changed bool
+
+	if err := st.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
+		typedRes := res.(*talos.Image) //nolint:forcetypeassert,errcheck
+
+		value := typedRes.TypedSpec().Value
+		changed = value.Schematic != schematic || value.Version != version
+
+		value.Schematic = schematic
+		value.Version = version
+
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	return changed, nil
+}
+
+// requestReboot simulates a node reboot by (re)creating a Reboot resource with a short downtime,
+// and rotates the boot ID as the kernel does on every boot.
+func (c *MachineService) requestReboot(ctx context.Context) error {
+	reboot := talos.NewReboot(talos.NamespaceName, talos.RebootID)
+	reboot.TypedSpec().Value.Downtime = durationpb.New(time.Second * 2)
+
+	if err := destroyResourceByID[*talos.Reboot](ctx, c.state, talos.RebootID); err != nil && !state.IsNotFoundError(err) {
+		return err
+	}
+
+	if err := c.state.Create(ctx, reboot); err != nil {
+		return err
+	}
+
+	c.rotateBootID()
+
+	return nil
+}
+
+// currentBootID returns the current kernel boot ID.
+func (c *MachineService) currentBootID() string {
+	return c.sharedMachineState.bootID.get()
+}
+
+// rotateBootID assigns a fresh kernel boot ID.
+func (c *MachineService) rotateBootID() {
+	c.sharedMachineState.bootID.rotate()
+}
+
+// errLifecycleInProgress is returned when a lifecycle install or upgrade is already running.
+var errLifecycleInProgress = status.Error(codes.FailedPrecondition, "another install or upgrade is already in progress")
+
+// errSequenceInProgress is returned when a machine-service sequence operation (upgrade or reboot) is already running.
+var errSequenceInProgress = status.Error(codes.FailedPrecondition, "another sequence is already running")
+
+// machineState is the per-machine emulator state shared between the machine and lifecycle services.
+// It is owned by the APID service, so it survives apid restarts (cert and address changes) and lets
+// the services observe the same boot ID and serialize operations within each Talos lock domain.
+type machineState struct {
+	bootID *kernelBootID
+	// lifecycleMu serializes LifecycleService.Install and Upgrade, mirroring the lifecycle lock.
+	lifecycleMu sync.Mutex
+	// sequenceMu serializes the machine service's sequence operations (Upgrade and Reboot), lightly mirroring the sequencer lock.
+	sequenceMu sync.Mutex
+}
+
+// newMachineState allocates per-machine state with a fresh boot ID.
+func newMachineState() *machineState {
+	return &machineState{bootID: newKernelBootID()}
+}
+
+// kernelBootID emulates /proc/sys/kernel/random/boot_id.
+type kernelBootID struct {
+	value string
+	mu    sync.Mutex
+}
+
+// newKernelBootID allocates a boot ID with a fresh value.
+func newKernelBootID() *kernelBootID {
+	return &kernelBootID{value: uuid.New().String()}
+}
+
+func (b *kernelBootID) get() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.value
+}
+
+func (b *kernelBootID) rotate() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.value = uuid.New().String()
 }
 
 type fakeProc struct {

--- a/internal/pkg/machine/services/machined_test.go
+++ b/internal/pkg/machine/services/machined_test.go
@@ -6,18 +6,64 @@ package services_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/talemu/internal/pkg/machine/services"
 )
+
+// recordingStream is a fake server-streaming gRPC stream that records every message sent to it.
+// Parameterizing by the response type replaces the per-RPC fake stream servers the tests would
+// otherwise duplicate.
+type recordingStream[T any] struct {
+	grpc.ServerStream
+
+	ctx  context.Context //nolint:containedctx
+	sent []T
+}
+
+func (s *recordingStream[T]) Context() context.Context { return s.ctx }
+
+func (s *recordingStream[T]) Send(msg T) error {
+	s.sent = append(s.sent, msg)
+
+	return nil
+}
+
+func newMachineService(t *testing.T) *services.MachineService {
+	t.Helper()
+
+	return services.NewMachineService(
+		"test-machine-id",
+		state.WrapCore(namespaced.NewState(inmem.Build)),
+		state.WrapCore(namespaced.NewState(inmem.Build)),
+		"factory.talos.dev",
+		zaptest.NewLogger(t),
+		nil,
+	)
+}
+
+// TestUpgradeNotInstalled asserts MachineService.Upgrade rejects an upgrade when not installed.
+func TestUpgradeNotInstalled(t *testing.T) {
+	svc := newMachineService(t)
+
+	_, err := svc.Upgrade(t.Context(), &machine.UpgradeRequest{
+		Image: "factory.talos.dev/installer/abc123:v1.14.0",
+	})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
 
 func TestApplyPartialConfiguration(t *testing.T) {
 	partialMachineConfig := `apiVersion: v1alpha1
@@ -31,7 +77,7 @@ url: "tcp://[fdae:41e4:649b:9303::1]:8092"`
 	apidState := state.WrapCore(namespaced.NewState(inmem.Build))
 	globalState := state.WrapCore(namespaced.NewState(inmem.Build))
 	logger := zaptest.NewLogger(t)
-	machineService := services.NewMachineService("test-machine-id", apidState, globalState, "factory.talos.dev", logger)
+	machineService := services.NewMachineService("test-machine-id", apidState, globalState, "factory.talos.dev", logger, nil)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -43,4 +89,39 @@ url: "tcp://[fdae:41e4:649b:9303::1]:8092"`
 	require.NoError(t, err)
 
 	require.Equal(t, machine.ApplyConfigurationRequest_NO_REBOOT, resp.Messages[0].Mode)
+}
+
+func TestReadBootID(t *testing.T) {
+	svc := newMachineService(t)
+	srv := &recordingStream[*common.Data]{ctx: t.Context()}
+
+	require.NoError(t, svc.Read(&machine.ReadRequest{Path: services.BootIDPath}, srv))
+	require.Len(t, srv.sent, 1)
+	require.NotEmpty(t, strings.TrimSpace(string(srv.sent[0].GetBytes())))
+}
+
+func TestReadUnsupportedPath(t *testing.T) {
+	svc := newMachineService(t)
+
+	err := svc.Read(&machine.ReadRequest{Path: "/etc/hostname"}, &recordingStream[*common.Data]{ctx: t.Context()})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+// TestRebootRotatesBootID asserts a reboot rotates the boot ID returned by Read.
+func TestRebootRotatesBootID(t *testing.T) {
+	svc := newMachineService(t)
+
+	read := func() string {
+		srv := &recordingStream[*common.Data]{ctx: t.Context()}
+		require.NoError(t, svc.Read(&machine.ReadRequest{Path: services.BootIDPath}, srv))
+
+		return strings.TrimSpace(string(srv.sent[0].GetBytes()))
+	}
+
+	before := read()
+
+	_, err := svc.Reboot(t.Context(), &machine.RebootRequest{})
+	require.NoError(t, err)
+
+	require.NotEqual(t, before, read())
 }


### PR DESCRIPTION
Implement ImageService.Pull, LifecycleService.Install/Upgrade and a boot-ID read to simulate maintenance install/upgrade.
