### PR TITLE
chore:  support uuid conflict resolution and uuid overrides

### DIFF
--- a/cmd/talemu-infra-provider/data/schema.json
+++ b/cmd/talemu-infra-provider/data/schema.json
@@ -6,6 +6,9 @@
     },
     "secure_boot": {
       "type": "boolean"
+    },
+    "uuid": {
+      "type": "string"
     }
   }
 }

--- a/cmd/talemu-infra-provider/main.go
+++ b/cmd/talemu-infra-provider/main.go
@@ -178,7 +178,7 @@ var rootCmd = &cobra.Command{
 			return ip.Run(ctx, logger, infra.WithOmniEndpoint(cfg.omniAPIEndpoint), infra.WithClientOptions(
 				client.WithServiceAccount(cfg.serviceAccountKey),
 				client.WithInsecureSkipTLSVerify(true),
-			))
+			), infra.WithEncodeRequestIDsIntoTokens())
 		})
 
 		eg.Go(func() error {

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/siderolabs/talemu
 
 go 1.26.4
 
-// forked go-yaml that introduces RawYAML interface, which can be used to populate YAML fields using bytes
-// which are then encoded as a valid YAML blocks with proper indentation
 replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20220527175918-f17b0f05cf2c
 
 replace (

--- a/internal/pkg/machine/controllers/hostname_config.go
+++ b/internal/pkg/machine/controllers/hostname_config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/nethelpers"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"go.uber.org/zap"
 
@@ -27,9 +28,7 @@ import (
 )
 
 // HostnameConfigController manages network.HostnameSpec based on machine configuration, kernel cmdline.
-type HostnameConfigController struct {
-	MachineID string
-}
+type HostnameConfigController struct{}
 
 // Name implements controller.Controller interface.
 func (ctrl *HostnameConfigController) Name() string {
@@ -55,6 +54,12 @@ func (ctrl *HostnameConfigController) Inputs() []controller.Input {
 			Namespace: cluster.NamespaceName,
 			Type:      cluster.IdentityType,
 			ID:        optional.Some(cluster.LocalIdentity),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: hardware.NamespaceName,
+			Type:      hardware.SystemInformationType,
+			ID:        optional.Some(hardware.SystemInformationID),
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -118,6 +123,21 @@ func (ctrl *HostnameConfigController) Run(ctx context.Context, r controller.Runt
 			defaultAddr = addrs.(*network.NodeAddress) //nolint:errcheck,forcetypeassert
 		}
 
+		// the default hostname is the machine UUID (including any override Omni assigned to resolve a
+		// UUID conflict), so it tracks the node UUID rather than the internal slot-based identifier.
+		var (
+			defaultHostname string
+			sysInfo         *hardware.SystemInformation
+		)
+
+		if sysInfo, err = safe.ReaderGetByID[*hardware.SystemInformation](ctx, r, hardware.SystemInformationID); err != nil {
+			if !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting system information: %w", err)
+			}
+		} else {
+			defaultHostname = sysInfo.TypedSpec().UUID
+		}
+
 		// parse machine configuration for specs
 		if cfgProvider != nil {
 			configHostname := ctrl.parseMachineConfiguration(logger, cfgProvider)
@@ -147,7 +167,7 @@ func (ctrl *HostnameConfigController) Run(ctx context.Context, r controller.Runt
 			}
 		} else {
 			specs = append(specs, network.HostnameSpecSpec{
-				Hostname:    ctrl.MachineID,
+				Hostname:    defaultHostname,
 				ConfigLayer: network.ConfigDefault,
 			})
 		}

--- a/internal/pkg/machine/controllers/siderolink.go
+++ b/internal/pkg/machine/controllers/siderolink.go
@@ -133,8 +133,23 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 		case <-r.EventCh():
 		}
 
+		// if the node UUID was overridden (e.g. by Omni resolving a UUID conflict via the UUIDOverride
+		// META key), drop the cached provision data so the machine re-provisions with the new UUID.
+		uuidChanged, err := ctrl.nodeUUIDChanged(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		if uuidChanged {
+			logger.Info("node UUID changed, re-provisioning", zap.String("node_uuid", ctrl.pd.nodeUUID))
+
+			ctrl.pd = provisionData{}
+		}
+
+		var provision optional.Optional[provisionData]
+
 		if ctrl.pd.IsEmpty() {
-			provision, err := ctrl.provision(ctx, r, logger)
+			provision, err = ctrl.provision(ctx, r, logger)
 			if err != nil {
 				return fmt.Errorf("error provisioning: %w", err)
 			}
@@ -267,6 +282,25 @@ func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, lo
 			zap.String("node_address", nodeAddress.String()),
 		)
 	}
+}
+
+// nodeUUIDChanged reports whether the machine is already provisioned but its current node UUID
+// differs from the one used for the active provision data.
+func (ctrl *ManagerController) nodeUUIDChanged(ctx context.Context, r controller.Runtime) (bool, error) {
+	if ctrl.pd.IsEmpty() {
+		return false, nil
+	}
+
+	sysInfo, err := safe.ReaderGetByID[*hardware.SystemInformation](ctx, r, hardware.SystemInformationID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to get system information: %w", err)
+	}
+
+	return sysInfo.TypedSpec().UUID != ctrl.pd.nodeUUID, nil
 }
 
 func (ctrl *ManagerController) provision(ctx context.Context, r controller.Runtime, logger *zap.Logger) (optional.Optional[provisionData], error) {

--- a/internal/pkg/machine/events/events.go
+++ b/internal/pkg/machine/events/events.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/netip"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -60,61 +59,121 @@ func (h *Handler) Run(ctx context.Context, logger *zap.Logger) error {
 		return err
 	}
 
+	endpoint := config.TypedSpec().Endpoint
+
+	// The siderolink address can change at runtime: when Omni resolves a UUID conflict it assigns a
+	// new UUID and the machine re-provisions, getting a brand new address. Events must originate from
+	// the address Omni currently associates with this machine, so watch the address and rebuild the
+	// event sink connection whenever it changes (the same way APIDController restarts its listener).
+	addressCh := make(chan state.Event)
+	if err = h.state.WatchKind(ctx, network.NewAddressStatus(network.NamespaceName, "").Metadata(), addressCh); err != nil {
+		return fmt.Errorf("failed to watch addresses: %w", err)
+	}
+
 	var (
-		bindAddress *net.TCPAddr
-		mu          sync.Mutex
+		boundAddr  netip.Addr
+		sinkEg     *errgroup.Group
+		stopSink   context.CancelFunc
+		haveRunner bool
 	)
 
+	teardownSink := func() {
+		if !haveRunner {
+			return
+		}
+
+		stopSink()
+		sinkEg.Wait() //nolint:errcheck
+
+		haveRunner = false
+	}
+
+	defer teardownSink()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-addressCh:
+			if ev.Type == state.Errored {
+				return fmt.Errorf("address watch failed: %w", ev.Error)
+			}
+		}
+
+		addr, linkName, ok, err := h.siderolinkAddress(ctx)
+		if err != nil {
+			return err
+		}
+
+		if !ok || addr == boundAddr {
+			continue
+		}
+
+		teardownSink()
+
+		boundAddr = addr
+
+		sinkCtx, cancelSink := context.WithCancel(ctx)
+
+		sinkEg, err = h.startEventSink(sinkCtx, logger, endpoint, addr, linkName)
+		if err != nil {
+			cancelSink()
+
+			return err
+		}
+
+		stopSink = cancelSink
+		haveRunner = true
+	}
+}
+
+// siderolinkAddress returns the current siderolink interface address, if any.
+func (h *Handler) siderolinkAddress(ctx context.Context) (netip.Addr, string, bool, error) {
+	list, err := safe.ReaderListAll[*network.AddressStatus](ctx, h.state)
+	if err != nil {
+		return netip.Addr{}, "", false, err
+	}
+
+	addr, ok := list.Find(func(r *network.AddressStatus) bool {
+		return strings.HasPrefix(r.TypedSpec().LinkName, constants.SideroLinkName)
+	})
+	if !ok {
+		return netip.Addr{}, "", false, nil
+	}
+
+	return addr.TypedSpec().Address.Addr(), addr.TypedSpec().LinkName, true, nil
+}
+
+// startEventSink dials the event sink bound to the given address and starts publishing events.
+// The returned group winds down (closing the connection) once ctx is canceled.
+func (h *Handler) startEventSink(ctx context.Context, logger *zap.Logger, endpoint string, addr netip.Addr, linkName string) (*errgroup.Group, error) {
+	bindAddress := net.TCPAddrFromAddrPort(netip.AddrPortFrom(addr, 0))
+
 	conn, err := grpc.NewClient(
-		config.TypedSpec().Endpoint,
+		endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithSharedWriteBuffer(true),
 		grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
-			mu.Lock()
-			defer mu.Unlock()
-
-			var (
-				dialer   net.Dialer
-				linkName string
-			)
-
-			if bindAddress == nil {
-				list, e := safe.ReaderListAll[*network.AddressStatus](ctx, h.state)
-				if err != nil {
-					return nil, e
-				}
-
-				addr, ok := list.Find(func(r *network.AddressStatus) bool {
-					return strings.HasPrefix(r.TypedSpec().LinkName, constants.SideroLinkName)
-				})
-				if !ok {
-					return nil, fmt.Errorf("failed to look up siderolink address")
-				}
-
-				siderolinkAddr := addr.TypedSpec().Address
-
-				bindAddress = net.TCPAddrFromAddrPort(netip.AddrPortFrom(
-					siderolinkAddr.Addr(),
-					0,
-				))
-
-				linkName = addr.TypedSpec().LinkName
-			}
+			var dialer net.Dialer
 
 			dialer.LocalAddr = bindAddress
-
 			dialer.Control = emunet.BindToInterface(linkName)
 
 			return dialer.DialContext(ctx, "tcp", address)
 		}),
 	)
 	if err != nil {
-		return fmt.Errorf("error establishing connection to event sink: %w", err)
+		return nil, fmt.Errorf("error establishing connection to event sink: %w", err)
 	}
 
-	defer conn.Close() //nolint:errcheck
+	eg, ctx := errgroup.WithContext(ctx)
 
-	var eg errgroup.Group
+	// close the connection once the context is canceled (address change or shutdown).
+	eg.Go(func() error {
+		<-ctx.Done()
+
+		return conn.Close()
+	})
 
 	client := events.NewEventSinkServiceClient(conn)
 
@@ -185,7 +244,7 @@ func (h *Handler) Run(ctx context.Context, logger *zap.Logger) error {
 		})
 	})
 
-	return eg.Wait()
+	return eg, nil
 }
 
 func (h *Handler) runWithRetries(ctx context.Context, logger *zap.Logger, cb func() error) error {

--- a/internal/pkg/machine/logging/sender.go
+++ b/internal/pkg/machine/logging/sender.go
@@ -20,11 +20,13 @@ import (
 
 // LogSender writes zap logs to the remote destination.
 type LogSender struct {
-	endpoint  *url.URL
 	conn      net.Conn
+	endpoint  *url.URL
 	sema      chan struct{}
-	iface     string
 	localAddr netip.Prefix
+	connAddr  netip.Prefix
+	iface     string
+	connIface string
 	mu        sync.Mutex
 }
 
@@ -105,6 +107,15 @@ func (j *LogSender) Send(ctx context.Context, e *LogEvent) error {
 
 	defer unlock()
 
+	// The bind address can change at runtime (e.g. when Omni resolves a UUID conflict the machine
+	// re-provisions and gets a new address). If the current connection is bound to a stale address,
+	// drop it so we redial and bind to the current one, otherwise Omni keeps receiving logs from an
+	// address it no longer associates with this machine.
+	if j.conn != nil && (j.connAddr != localAddr || j.connIface != iface) {
+		j.conn.Close() //nolint:errcheck
+		j.conn = nil
+	}
+
 	var dialer net.Dialer
 
 	dialer.LocalAddr = net.TCPAddrFromAddrPort(netip.AddrPortFrom(localAddr.Addr(), 0))
@@ -118,6 +129,8 @@ func (j *LogSender) Send(ctx context.Context, e *LogEvent) error {
 		}
 
 		j.conn = conn
+		j.connAddr = localAddr
+		j.connIface = iface
 	}
 
 	d, _ := ctx.Deadline()

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -102,10 +102,15 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 	defer logSink.Close(ctx) //nolint:errcheck
 
-	m.logger = zap.New(core).With(zap.String("machine", m.uuid))
+	// The internal machine identifier is derived from the unique slot rather than the UUID:
+	// UUIDs can be duplicated (e.g. when forcing UUID conflicts), and using them for per-machine
+	// state would make machines clobber each other's state directory and resources.
+	machineID := truntime.MachineID(slot)
+
+	m.logger = zap.New(core).With(zap.String("machine", machineID), zap.String("uuid", m.uuid))
 
 	rt, err := truntime.NewRuntime(
-		ctx, m.logger, slot, m.uuid, m.globalState,
+		ctx, m.logger, slot, machineID, m.globalState,
 		kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService,
 		m.imageFactoryHost, opts.nodeProxyingDisabled,
 	)

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -95,9 +95,7 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 		},
 		&controllers.GRPCTLSController{},
 		&controllers.MachineTypeController{},
-		&controllers.HostnameConfigController{
-			MachineID: id,
-		},
+		&controllers.HostnameConfigController{},
 		&controllers.HostnameMergeController{},
 		&controllers.HostnameSpecController{
 			GlobalState: globalState,

--- a/internal/pkg/machine/runtime/state.go
+++ b/internal/pkg/machine/runtime/state.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
@@ -137,4 +138,14 @@ func newBoltStateBuilder(path string, options *bbolt.Options, compact bool, logg
 // GetStateDir constructs state directory for the machine.
 func GetStateDir(id string) string {
 	return filepath.Join("_out/state/machines", id)
+}
+
+// MachineID returns the stable unique identifier for the machine occupying the given slot.
+//
+// The slot is used instead of the node UUID because UUIDs can be intentionally duplicated
+// (e.g. when forcing UUID conflicts for testing), while slots are always unique. Keying
+// per-machine state (state directory, machine status resource, certificates, ...) on the slot
+// keeps machines isolated even when several of them share the same UUID.
+func MachineID(slot int) string {
+	return strconv.Itoa(slot)
 }

--- a/internal/pkg/machine/services/machined.go
+++ b/internal/pkg/machine/services/machined.go
@@ -21,9 +21,11 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/meta"
 	"github.com/siderolabs/talos/pkg/machinery/resources/block"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
+	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
@@ -798,6 +800,15 @@ func (c *MachineService) MetaWrite(ctx context.Context, req *machine.MetaWriteRe
 		}
 	}
 
+	// UUIDOverride is written by Omni to resolve UUID conflicts: emulate the real Talos behavior
+	// by replacing the node UUID (e.g. the all-zeroes UUID produced with forced conflicts) with the
+	// overridden one, so the machine reconnects to SideroLink with its new unique UUID.
+	if req.Key == meta.UUIDOverride {
+		if err := c.overrideNodeUUID(ctx, string(req.Value)); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := c.state.Create(ctx, metaKey); err != nil {
 		if !state.IsConflictError(err) {
 			return nil, err
@@ -897,6 +908,21 @@ func (c *MachineService) createOrUpdateUniqueToken(ctx context.Context, req *mac
 	})
 
 	return err
+}
+
+func (c *MachineService) overrideNodeUUID(ctx context.Context, uuid string) error {
+	_, err := safe.StateUpdateWithConflicts(ctx, c.state, hardware.NewSystemInformation(hardware.SystemInformationID).Metadata(), func(r *hardware.SystemInformation) error {
+		r.TypedSpec().UUID = uuid
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	c.logger.Info("overrode node UUID", zap.String("uuid", uuid))
+
+	return nil
 }
 
 // SystemStat implements machine.MachineServiceServer.

--- a/internal/pkg/provider/controllers/machine_runner.go
+++ b/internal/pkg/provider/controllers/machine_runner.go
@@ -138,18 +138,20 @@ func (ctrl *MachineController) Run(ctx context.Context, r controller.Runtime, lo
 }
 
 func (ctrl *MachineController) resetMachine(ctx context.Context, m *resources.MachineTask, logger *zap.Logger) error {
-	logger.Info("reset machine", zap.String("uuid", m.TypedSpec().Value.Uuid), zap.String("request", m.Metadata().ID()))
+	machineID := runtime.MachineID(int(m.TypedSpec().Value.Slot))
+
+	logger.Info("reset machine", zap.String("machine", machineID), zap.String("uuid", m.TypedSpec().Value.Uuid), zap.String("request", m.Metadata().ID()))
 
 	ctrl.runner.StopTask(logger, m.Metadata().ID())
 
-	stateDir := runtime.GetStateDir(m.TypedSpec().Value.Uuid)
+	stateDir := runtime.GetStateDir(machineID)
 
 	err := os.RemoveAll(stateDir)
-	if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	err = ctrl.globalState.Destroy(ctx, emu.NewMachineStatus(emu.NamespaceName, m.TypedSpec().Value.Uuid).Metadata())
+	err = ctrl.globalState.Destroy(ctx, emu.NewMachineStatus(emu.NamespaceName, machineID).Metadata())
 	if err != nil && !state.IsNotFoundError(err) {
 		return err
 	}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -36,7 +36,8 @@ func NewProvisioner(state state.State) *Provisioner {
 }
 
 type providerData struct {
-	SecureBoot bool `yaml:"secure_boot"`
+	UUID       string `yaml:"uuid"`
+	SecureBoot bool   `yaml:"secure_boot"`
 }
 
 // ProvisionSteps implements infra.Provisioner.
@@ -57,7 +58,6 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 			// the machine is already provisioned, so no need to do anything, just return the current machine state
 			if machineTask != nil {
-				pctx.SetMachineUUID(machineTask.TypedSpec().Value.Uuid)
 				pctx.SetMachineInfraID(fmt.Sprintf("%d", machineTask.TypedSpec().Value.Slot))
 
 				return nil
@@ -73,7 +73,13 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					return fmt.Errorf("failed to pick a free slot: %w", err)
 				}
 
-				machine.TypedSpec().Value.Uuid = fmt.Sprintf("%06d03-c798-4da7-a410-f09abb48c8d8", machine.TypedSpec().Value.Slot)
+				if pd.UUID != "" {
+					logger.Warn("machine UUID is overridden via provider data; reusing the same UUID across machines fakes a conflict that should be handled gracefully", zap.String("uuid", pd.UUID))
+
+					machine.TypedSpec().Value.Uuid = pd.UUID
+				} else {
+					machine.TypedSpec().Value.Uuid = fmt.Sprintf("%06d03-c798-4da7-a410-f09abb48c8d8", machine.TypedSpec().Value.Slot)
+				}
 
 				machine.TypedSpec().Value.Schematic, err = pctx.GenerateSchematicID(ctx, logger, provision.WithoutConnectionParams())
 				if err != nil {
@@ -96,7 +102,6 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				SecureBoot:     pd.SecureBoot,
 			}
 
-			pctx.SetMachineUUID(machineTask.TypedSpec().Value.Uuid)
 			pctx.SetMachineInfraID(fmt.Sprintf("%d", machineTask.TypedSpec().Value.Slot))
 
 			if err = p.state.Create(ctx, machineTask); err != nil {


### PR DESCRIPTION
Now it's possible to override created machines UUIDs using the provider data and Talemu properly simulates real Talos behavior when UUID conflict happens and Omni writes the new random UUID back to the node.

This flow is going to be used in Omni to cover UUID conflict resolution code.