### PR TITLE
fix: disable idle mode on in-process loopback connection

### DIFF
--- a/internal/pkg/machine/services/apid/pkg/backend/local.go
+++ b/internal/pkg/machine/services/apid/pkg/backend/local.go
@@ -66,6 +66,11 @@ func (l *Local) GetConnection(ctx context.Context, _ string) (context.Context, *
 		),
 		grpc.WithDefaultCallOptions(grpc.ForceCodecV2(proxy.Codec())),
 		grpc.WithSharedWriteBuffer(true),
+		// Disable idle mode: this is a permanent in-process loopback connection,
+		// so there is nothing to reclaim by going idle, and it avoids the
+		// first-request latency of re-establishing the connection after a quiet
+		// period.
+		grpc.WithIdleTimeout(0),
 	)
 
 	return outCtx, l.conn, err


### PR DESCRIPTION
The local backend talks to the in-process apid server over an in-memory loopback transport, which has no use for gRPC idle mode since there is nothing to reclaim by going idle. This mirrors the same change made in Omni in siderolabs/omni#3011, and also bypasses a gRPC bug that can leave an idling connection permanently stuck.