### PR TITLE
fix: unblock Talos upgrades utilizing LifecycleService.Upgrade

### DIFF
--- a/internal/pkg/machine/controllers/etcd.go
+++ b/internal/pkg/machine/controllers/etcd.go
@@ -72,64 +72,45 @@ func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logge
 		return err
 	}
 
-outer:
 	for {
-		var clusterID string
-
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-r.EventCh():
+			// The machine's own config can arrive after the cluster has already bootstrapped (e.g. a control
+			// plane joining an existing cluster). Reconcile here so etcd still comes up in that ordering, not
+			// only when the global cluster status changes.
+			if err := ctrl.reconcile(ctx, r, logger); err != nil {
+				return err
+			}
 		case event := <-watchEvents:
 			switch event.Type {
 			case state.Errored:
 				return event.Error
 			case state.Bootstrapped, state.Noop:
-				continue outer
+				continue
 			case state.Destroyed, state.Created, state.Updated:
-				clusterID = event.Resource.Metadata().ID()
 			}
 
-			config, err := machineconfig.GetComplete(ctx, r)
-			if err != nil && !state.IsNotFoundError(err) {
-				return err
-			}
-
-			if clusterID != "" && config != nil && clusterID != config.Provider().Cluster().ID() {
-				continue
-			}
-
-			if config == nil || !config.Provider().Machine().Type().IsControlPlane() {
-				if err = ctrl.reconcileTeardown(ctx, r, logger); err != nil {
-					return err
-				}
-
-				continue
-			}
-
-			if err = ctrl.reconcileRunning(ctx, r, config, logger); err != nil {
+			if err := ctrl.reconcile(ctx, r, logger); err != nil {
 				return err
 			}
 		}
 	}
 }
 
-func (ctrl *EtcdController) reconcileTeardown(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
-	if err := ctrl.resetETCDMember(ctx, logger); err != nil {
-		return err
-	}
-
-	err := r.Destroy(ctx, etcd.NewMember(etcd.NamespaceName, etcd.LocalMemberID).Metadata())
+// reconcile ensures the etcd service and member are present for a control-plane machine.
+func (ctrl *EtcdController) reconcile(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	config, err := machineconfig.GetComplete(ctx, r)
 	if err != nil && !state.IsNotFoundError(err) {
 		return err
 	}
 
-	err = r.Destroy(ctx, v1alpha1.NewService(constants.ETCDService).Metadata())
-	if err != nil && !state.IsNotFoundError(err) {
-		return err
+	if config == nil || !config.Provider().Machine().Type().IsControlPlane() {
+		return nil
 	}
 
-	return nil
+	return ctrl.reconcileRunning(ctx, r, config, logger)
 }
 
 func (ctrl *EtcdController) reconcileRunning(ctx context.Context, r controller.Runtime, config *config.MachineConfig, logger *zap.Logger) error {
@@ -153,6 +134,12 @@ func (ctrl *EtcdController) reconcileRunning(ctx context.Context, r controller.R
 
 	clusterStatus, err := safe.ReaderGetByID[*emu.ClusterStatus](ctx, ctrl.GlobalState, config.Provider().Cluster().ID())
 	if err != nil {
+		if state.IsNotFoundError(err) {
+			// Config landed before the cluster status was published. Leave etcd not-ready and wait: the
+			// cluster status watch will trigger another reconcile once it appears.
+			return nil
+		}
+
 		return err
 	}
 
@@ -207,20 +194,4 @@ func (ctrl *EtcdController) genETCDMember(ctx context.Context) (string, error) {
 	}
 
 	return member, nil
-}
-
-func (ctrl *EtcdController) resetETCDMember(ctx context.Context, logger *zap.Logger) error {
-	if _, err := safe.StateUpdateWithConflicts(ctx, ctrl.GlobalState, emu.NewMachineStatus(emu.NamespaceName, ctrl.MachineID).Metadata(), func(res *emu.MachineStatus) error {
-		if res.TypedSpec().Value.EtcdMemberId != "" {
-			logger.Info("reset etcd member")
-		}
-
-		res.TypedSpec().Value.EtcdMemberId = ""
-
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/internal/pkg/machine/controllers/etcd_test.go
+++ b/internal/pkg/machine/controllers/etcd_test.go
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers_test
+
+import (
+	"context"
+	"testing"
+
+	cosiruntime "github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	configv1alpha1 "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/talemu/internal/pkg/constants"
+	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/emu"
+)
+
+var etcdServiceID = v1alpha1.NewService(constants.ETCDService).Metadata().ID()
+
+// TestEtcdControllerReconcilesOnConfig verifies that a control-plane machine brings up its etcd service off
+// its own config event, without needing a cluster-status change to trigger the reconcile. This is the path a
+// control plane joining an already-bootstrapped cluster takes (e.g. after a maintenance upgrade delays its
+// config apply past bootstrap): the config lands after the bootstrap event, so etcd must come up on the
+// config event alone.
+func TestEtcdControllerReconcilesOnConfig(t *testing.T) {
+	t.Parallel()
+
+	const (
+		machineID = "test-machine"
+		clusterID = "test-cluster"
+	)
+
+	ctx := t.Context()
+
+	globalState := state.WrapCore(namespaced.NewState(inmem.Build))
+	localState := startEtcdController(t, ctx, globalState, machineID)
+
+	// A control-plane config with no cluster status present yet. On the fixed controller the config event
+	// triggers a reconcile that publishes the etcd service (not yet healthy, still waiting for bootstrap). The
+	// pre-fix controller ignored config events, so the service would never appear.
+	require.NoError(t, localState.Create(ctx, controlPlaneConfig(t, clusterID)))
+
+	rtestutils.AssertResource(ctx, t, localState, etcdServiceID, func(res *v1alpha1.Service, a *assert.Assertions) {
+		a.False(res.TypedSpec().Healthy, "etcd must not be healthy before the cluster is bootstrapped")
+		a.False(res.TypedSpec().Running, "etcd must not be running before the cluster is bootstrapped")
+	})
+
+	// Bootstrapping the cluster must flip etcd to healthy.
+	bootstrapCluster(t, ctx, globalState, clusterID)
+
+	rtestutils.AssertResource(ctx, t, localState, etcdServiceID, func(res *v1alpha1.Service, a *assert.Assertions) {
+		a.True(res.TypedSpec().Healthy, "etcd must become healthy once the cluster is bootstrapped")
+		a.True(res.TypedSpec().Running)
+	})
+}
+
+// TestEtcdControllerControlPlanesRegisterOnBootstrap reproduces a rolling control-plane join: several control
+// planes, whose configs land at different times relative to the cluster bootstrap, must each bring up etcd.
+// The integration failure was a 3-CP cluster stuck at 2 etcd members because one CP never registered.
+func TestEtcdControllerControlPlanesRegisterOnBootstrap(t *testing.T) {
+	t.Parallel()
+
+	const clusterID = "test-cluster"
+
+	ctx := t.Context()
+
+	globalState := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	// Model different config-vs-bootstrap orderings across the control planes: two apply their config before
+	// the cluster bootstraps, the third only after (the case that regressed).
+	early := []string{"1", "2"}
+	late := "3"
+
+	localStates := map[string]state.State{}
+
+	for _, id := range early {
+		localStates[id] = startEtcdController(t, ctx, globalState, id)
+		require.NoError(t, localStates[id].Create(ctx, controlPlaneConfig(t, clusterID)))
+	}
+
+	localStates[late] = startEtcdController(t, ctx, globalState, late)
+
+	bootstrapCluster(t, ctx, globalState, clusterID)
+
+	require.NoError(t, localStates[late].Create(ctx, controlPlaneConfig(t, clusterID)))
+
+	for id, localState := range localStates {
+		rtestutils.AssertResource(ctx, t, localState, etcdServiceID, func(res *v1alpha1.Service, a *assert.Assertions) {
+			a.Truef(res.TypedSpec().Healthy, "etcd must be healthy on control plane %q", id)
+		})
+
+		rtestutils.AssertResource(ctx, t, globalState, id, func(res *emu.MachineStatus, a *assert.Assertions) {
+			a.NotEmptyf(res.TypedSpec().Value.EtcdMemberId, "control plane %q must register an etcd member", id)
+		})
+	}
+}
+
+// startEtcdController stands up an in-memory machine runtime with only the EtcdController registered, sharing
+// globalState with the other machines, and returns the machine's local state. It mirrors the provider seeding
+// the machine's global status before the runtime starts.
+func startEtcdController(t *testing.T, ctx context.Context, globalState state.State, machineID string) state.State {
+	t.Helper()
+
+	localState := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	require.NoError(t, globalState.Create(ctx, emu.NewMachineStatus(emu.NamespaceName, machineID)))
+
+	rt, err := cosiruntime.NewRuntime(localState, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.RegisterController(&controllers.EtcdController{
+		GlobalState: globalState,
+		MachineID:   machineID,
+	}))
+
+	// Wait for the runtime to fully stop before the test returns, otherwise its goroutine can log through the
+	// zaptest logger after the test has completed and panic.
+	runtimeCtx, stopRuntime := context.WithCancel(ctx)
+
+	var eg errgroup.Group
+
+	eg.Go(func() error { return rt.Run(runtimeCtx) })
+
+	t.Cleanup(func() {
+		stopRuntime()
+
+		require.NoError(t, eg.Wait())
+	})
+
+	return localState
+}
+
+func bootstrapCluster(t *testing.T, ctx context.Context, globalState state.State, clusterID string) {
+	t.Helper()
+
+	clusterStatus := emu.NewClusterStatus(emu.NamespaceName, clusterID)
+	clusterStatus.TypedSpec().Value.Bootstrapped = true
+
+	require.NoError(t, globalState.Create(ctx, clusterStatus))
+}
+
+func controlPlaneConfig(t *testing.T, clusterID string) *config.MachineConfig {
+	t.Helper()
+
+	provider, err := container.New(&configv1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &configv1alpha1.MachineConfig{
+			MachineType: "controlplane",
+			MachineInstall: &configv1alpha1.InstallConfig{
+				InstallImage: "factory.talos.dev/installer/abc123:v1.14.0",
+			},
+		},
+		ClusterConfig: &configv1alpha1.ClusterConfig{
+			ClusterID: clusterID,
+		},
+	})
+	require.NoError(t, err)
+
+	return config.NewMachineConfig(provider)
+}

--- a/internal/pkg/machine/controllers/machine_status.go
+++ b/internal/pkg/machine/controllers/machine_status.go
@@ -31,7 +31,8 @@ import (
 // MachineStatusController computes machine state from the existing resources.
 // Updates machine status resource.
 type MachineStatusController struct {
-	State state.State
+	State            state.State
+	ImageFactoryHost string
 }
 
 // Name implements controller.Controller interface.
@@ -229,9 +230,36 @@ func (ctrl *MachineStatusController) reconcile(ctx context.Context, r controller
 		return err
 	}
 
+	// A config-apply install writes the config's install image to disk, so the running Talos
+	// version and schematic become that image. Omni's same-minor maintenance-install path relies on
+	// this instead of an explicit LifecycleService.Install, so without it the machine keeps reporting
+	// its boot version and never reaches the target the cluster was created with.
+	if err = ctrl.setInstalledImage(ctx, installConfig.Image()); err != nil {
+		return err
+	}
+
 	return safe.WriterModify(ctx, r, block.NewSystemDisk(block.NamespaceName, block.SystemDiskID), func(r *block.SystemDisk) error {
 		r.TypedSpec().DiskID = installDisk.Metadata().ID()
 		r.TypedSpec().DevPath = filepath.Join("/dev/", installDisk.Metadata().ID())
+
+		return nil
+	})
+}
+
+// setInstalledImage records the config's install image as the machine's current on-disk image.
+// talos.Image is owned by no controller (the services mutate it directly), so it is updated through
+// the raw state here rather than a controller output.
+func (ctrl *MachineStatusController) setInstalledImage(ctx context.Context, imageRef string) error {
+	schematic, version, err := talos.ParseImageRef(ctrl.ImageFactoryHost, imageRef)
+	if err != nil {
+		return err
+	}
+
+	return ctrl.State.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
+		value := res.(*talos.Image).TypedSpec().Value //nolint:forcetypeassert,errcheck
+
+		value.Schematic = schematic
+		value.Version = version
 
 		return nil
 	})

--- a/internal/pkg/machine/controllers/static_pods.go
+++ b/internal/pkg/machine/controllers/static_pods.go
@@ -218,6 +218,15 @@ func (ctrl *StaticPodController) reconcile(ctx context.Context, r controller.Run
 		pod.Labels[machineIDLabel] = ctrl.MachineID
 		pod.Labels[inputVersionLabel] = nodenameVersion
 
+		// The control-plane components run as static pods on real Talos, so a node drain skips them (a
+		// kubelet marks its static pods with the mirror annotation). Mirror that here, otherwise draining a
+		// control-plane machine (e.g. during an upgrade) blocks forever waiting for these pods to terminate.
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+
+		pod.Annotations[v1.MirrorPodAnnotationKey] = ctrl.MachineID
+
 		pod.Spec.SchedulerName = "default-scheduler"
 		pod.Spec.NodeName = nodename.TypedSpec().Nodename
 		pod.Spec.HostNetwork = true

--- a/internal/pkg/machine/runtime/resources/talos/image.go
+++ b/internal/pkg/machine/runtime/resources/talos/image.go
@@ -5,6 +5,9 @@
 package talos
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
@@ -19,6 +22,30 @@ func NewImage(ns, id string) *Image {
 		resource.NewMetadata(ns, ImageType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.ImageSpec{}),
 	)
+}
+
+// ParseImageRef splits an installer image reference into its schematic id and Talos version.
+// The schematic is only recoverable when the reference points at the image factory host, since
+// only those references carry it as the repository path segment.
+func ParseImageRef(imageFactoryHost, imageRef string) (schematic, version string, err error) {
+	ref := imageRef
+
+	if at := strings.IndexByte(ref, '@'); at != -1 {
+		ref = ref[:at]
+	}
+
+	parts := strings.Split(ref, "/")
+
+	schematicCandidate, version, found := strings.Cut(parts[len(parts)-1], ":")
+	if !found {
+		return "", "", fmt.Errorf("failed to parse the image %q", imageRef)
+	}
+
+	if parts[0] == imageFactoryHost {
+		schematic = schematicCandidate
+	}
+
+	return schematic, version, nil
 }
 
 const (

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -116,7 +116,7 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 			SchematicService: schematicService,
 			ImageFactoryHost: imageFactoryHost,
 		},
-		&controllers.MachineStatusController{State: st},
+		&controllers.MachineStatusController{State: st, ImageFactoryHost: imageFactoryHost},
 		&controllers.VersionController{},
 		&controllers.NodeIdentityController{},
 		&controllers.NodenameController{},

--- a/internal/pkg/machine/services/apid.go
+++ b/internal/pkg/machine/services/apid.go
@@ -197,7 +197,7 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 		}
 
 		err = localServer.Serve(listener)
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, grpc.ErrServerStopped) {
 			return nil
 		}
 
@@ -206,7 +206,7 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 
 	eg.Go(func() error {
 		err := s.Serve(lis)
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, grpc.ErrServerStopped) {
 			return nil
 		}
 
@@ -214,9 +214,20 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	})
 
 	eg.Go(func() error {
+		var reboot bool
+
 		select {
 		case <-ctx.Done():
 		case <-apid.shutdown:
+			reboot = true
+		}
+
+		if reboot {
+			// Force-stop the servers so clients observe the reboot instead of a graceful drain.
+			s.Stop()
+			localServer.Stop()
+
+			return nil
 		}
 
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -226,10 +237,6 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 		ServerGracefulStop(localServer, shutdownCtx) //nolint:contextcheck
 
 		return nil
-	})
-
-	eg.Go(func() error {
-		return s.Serve(lis)
 	})
 
 	return nil

--- a/internal/pkg/machine/services/machined.go
+++ b/internal/pkg/machine/services/machined.go
@@ -567,16 +567,23 @@ func (c *MachineService) EtcdForfeitLeadership(context.Context, *machine.EtcdFor
 }
 
 func (c *MachineService) EtcdStatus(ctx context.Context, _ *emptypb.Empty) (*machine.EtcdStatusResponse, error) {
-	member, err := safe.ReaderGetByID[*etcd.Member](ctx, c.state, etcd.LocalMemberID)
+	// Read the member from the shared global status, the same durable source EtcdMemberList uses, so the two
+	// RPCs always agree and both survive reboots.
+	machineStatus, err := safe.ReaderGetByID[*emu.MachineStatus](ctx, c.globalState, c.machineID)
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return nil, status.Errorf(codes.InvalidArgument, "the machine doesn't have etcd member")
 		}
 
-		return nil, fmt.Errorf("failed to get etcd member %w", err)
+		return nil, fmt.Errorf("failed to get machine status %w", err)
 	}
 
-	id, err := etcd.ParseMemberID(member.TypedSpec().MemberID)
+	memberID := machineStatus.TypedSpec().Value.EtcdMemberId
+	if memberID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "the machine doesn't have etcd member")
+	}
+
+	id, err := etcd.ParseMemberID(memberID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to parse etcd member id %s", err.Error())
 	}
@@ -761,9 +768,10 @@ func (c *MachineService) ImagePull(ctx context.Context, req *machine.ImagePullRe
 	}, nil
 }
 
-// cacheImage records a pulled image as a CachedImage and returns its digest, derived from the reference so it is stable across calls.
+// cacheImage records a pulled image and returns a digest derived from the reference, so it stays
+// stable across calls.
 func cacheImage(ctx context.Context, st state.State, ref string) (string, error) {
-	// The emulator fails on a "-bad" suffix, mapped to the not-found code Talos returns for a missing image, so both pull entry points reject it consistently.
+	// A "-bad" suffix stands in for a missing image, so both pull paths reject it the way Talos does.
 	if strings.HasSuffix(ref, "-bad") {
 		return "", status.Errorf(codes.NotFound, "image %q not found", ref)
 	}
@@ -1021,30 +1029,17 @@ func (c *MachineService) Processes(_ context.Context, _ *emptypb.Empty) (*machin
 	}, nil
 }
 
-// setImage records the target Talos image on the machine and reports whether it differs from the image already recorded, so callers can avoid a needless reboot on a redundant upgrade.
+// setImage records the target Talos image and reports whether it changed, so a redundant upgrade to
+// the running image can skip the reboot.
 func setImage(ctx context.Context, st state.State, imageFactoryHost, imageRef string) (bool, error) {
-	ref := imageRef
-
-	if at := strings.IndexByte(ref, '@'); at != -1 {
-		ref = ref[:at]
-	}
-
-	parts := strings.Split(ref, "/")
-
-	s, version, found := strings.Cut(parts[len(parts)-1], ":")
-	if !found {
-		return false, status.Errorf(codes.InvalidArgument, "failed to parse the image %q", imageRef)
-	}
-
-	var schematic string
-
-	if parts[0] == imageFactoryHost {
-		schematic = s
+	schematic, version, err := talos.ParseImageRef(imageFactoryHost, imageRef)
+	if err != nil {
+		return false, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	var changed bool
 
-	if err := st.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
+	if err = st.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
 		typedRes := res.(*talos.Image) //nolint:forcetypeassert,errcheck
 
 		value := typedRes.TypedSpec().Value


### PR DESCRIPTION
Omni's LifecycleService rolling-upgrade path stalled in talemu for several independent reasons, each fixed here:
  - Reconcile etcd on the machine's own config event and stop tearing the member down on a transient config-absence, so a control plane that joins after bootstrap or reboots mid-upgrade keeps its membership instead of churning Omni's health check.
  - Write the config's install image to disk on a config-apply install, so the reported version becomes the target and a same-minor maintenance install actually works.
 - Add the kubelet mirror annotation to control-plane static pods, so draining the node no longer blocks forever waiting on them.
 - Force-stop apid on reboot (and treat a stopped server as a clean shutdown), so Omni's long-lived watch sees the restart instead of riding through the short downtime and missing the bootID change.
  - Serve EtcdStatus from the durable global machine status, the same source EtcdMemberList uses, so the two RPCs agree and both survive reboots.
