### PR TITLE
fix: write cluster and control-plane labels with etcd member

### DIFF
--- a/internal/pkg/machine/controllers/etcd.go
+++ b/internal/pkg/machine/controllers/etcd.go
@@ -158,13 +158,25 @@ func (ctrl *EtcdController) reconcileRunning(ctx context.Context, r controller.R
 
 		logger.Info("generated etcd member")
 
-		if res.TypedSpec().MemberID, err = ctrl.genETCDMember(ctx); err != nil {
-			return err
+		memberID, genErr := genMemberID()
+		if genErr != nil {
+			return genErr
 		}
+
+		res.TypedSpec().MemberID = memberID
 
 		return nil
 	})
 	if err != nil {
+		return err
+	}
+
+	// EtcdMemberList/EtcdStatus read the member from the shared global status and filter it by the cluster
+	// and control-plane labels. Those labels are otherwise written once by ApplyConfiguration, separately
+	// from the member, so a machine could end up with a member but no labels and drop out of the member
+	// list. Write both together here, every reconcile, so a control plane that has a member is always
+	// counted for its cluster.
+	if err = ctrl.syncGlobalMember(ctx, config.Provider().Cluster().ID(), member.TypedSpec().MemberID); err != nil {
 		return err
 	}
 
@@ -177,21 +189,24 @@ func (ctrl *EtcdController) reconcileRunning(ctx context.Context, r controller.R
 	return nil
 }
 
-func (ctrl *EtcdController) genETCDMember(ctx context.Context) (string, error) {
+func genMemberID() (string, error) {
 	buf := make([]byte, 8)
 	if _, err := rand.Read(buf); err != nil {
 		return "", err
 	}
 
-	member := etcd.FormatMemberID(binary.LittleEndian.Uint64(buf))
+	return etcd.FormatMemberID(binary.LittleEndian.Uint64(buf)), nil
+}
 
-	if _, err := safe.StateUpdateWithConflicts(ctx, ctrl.GlobalState, emu.NewMachineStatus(emu.NamespaceName, ctrl.MachineID).Metadata(), func(res *emu.MachineStatus) error {
-		res.TypedSpec().Value.EtcdMemberId = member
+func (ctrl *EtcdController) syncGlobalMember(ctx context.Context, clusterID, memberID string) error {
+	_, err := safe.StateUpdateWithConflicts(ctx, ctrl.GlobalState, emu.NewMachineStatus(emu.NamespaceName, ctrl.MachineID).Metadata(), func(res *emu.MachineStatus) error {
+		res.TypedSpec().Value.EtcdMemberId = memberID
+
+		res.Metadata().Labels().Set(emu.LabelCluster, clusterID)
+		res.Metadata().Labels().Set(emu.LabelControlPlaneRole, "")
 
 		return nil
-	}); err != nil {
-		return "", err
-	}
+	})
 
-	return member, nil
+	return err
 }

--- a/internal/pkg/machine/controllers/etcd_test.go
+++ b/internal/pkg/machine/controllers/etcd_test.go
@@ -103,6 +103,14 @@ func TestEtcdControllerControlPlanesRegisterOnBootstrap(t *testing.T) {
 
 		rtestutils.AssertResource(ctx, t, globalState, id, func(res *emu.MachineStatus, a *assert.Assertions) {
 			a.NotEmptyf(res.TypedSpec().Value.EtcdMemberId, "control plane %q must register an etcd member", id)
+
+			// EtcdMemberList filters the global status by these labels, so the member is only counted when
+			// they are written alongside it. Assert both are present on the same status as the member.
+			cluster, hasCluster := res.Metadata().Labels().Get(emu.LabelCluster)
+			a.Truef(hasCluster && cluster == clusterID, "control plane %q must carry the cluster label with its member", id)
+
+			_, hasControlPlane := res.Metadata().Labels().Get(emu.LabelControlPlaneRole)
+			a.Truef(hasControlPlane, "control plane %q must carry the control-plane label with its member", id)
 		})
 	}
 }


### PR DESCRIPTION
EtcdMemberList and EtcdStatus filter the shared global MachineStatus by cluster and control-plane labels. Those labels were written once by ApplyConfiguration, separately from the etcd member ID, so a machine could end up with a member ID but no labels and drop out of the member list. Write the member ID and both labels together on every reconcile so a control plane with a member is always counted for its cluster.