### PR TITLE
feat: support emulating Talos Enterprise machines

### DIFF
--- a/api/specs/specs.pb.go
+++ b/api/specs/specs.pb.go
@@ -261,11 +261,14 @@ func (x *VersionSpec) GetArchitecture() string {
 	return ""
 }
 
-// ImageSpec is the last image used in the upgrade request.
+// ImageSpec is the current emulated Talos image, written by config-apply installs and the
+// install/upgrade APIs.
 type ImageSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
-	Schematic     string                 `protobuf:"bytes,2,opt,name=schematic,proto3" json:"schematic,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Version   string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	Schematic string                 `protobuf:"bytes,2,opt,name=schematic,proto3" json:"schematic,omitempty"`
+	// Host is the registry host of the image ref, empty when the ref carries no host.
+	Host          string `protobuf:"bytes,3,opt,name=host,proto3" json:"host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -310,6 +313,13 @@ func (x *ImageSpec) GetVersion() string {
 func (x *ImageSpec) GetSchematic() string {
 	if x != nil {
 		return x.Schematic
+	}
+	return ""
+}
+
+func (x *ImageSpec) GetHost() string {
+	if x != nil {
+		return x.Host
 	}
 	return ""
 }
@@ -588,6 +598,9 @@ type MachineTaskSpec struct {
 	TalosVersion   string                 `protobuf:"bytes,4,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
 	ConnectionArgs string                 `protobuf:"bytes,5,opt,name=connection_args,json=connectionArgs,proto3" json:"connection_args,omitempty"`
 	SecureBoot     bool                   `protobuf:"varint,6,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
+	// BootFactoryUrl is the base URL of the image factory the machine's boot media is pretended
+	// to come from, empty to use the provider's configured factory.
+	BootFactoryUrl string `protobuf:"bytes,7,opt,name=boot_factory_url,json=bootFactoryUrl,proto3" json:"boot_factory_url,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -662,6 +675,13 @@ func (x *MachineTaskSpec) GetSecureBoot() bool {
 		return x.SecureBoot
 	}
 	return false
+}
+
+func (x *MachineTaskSpec) GetBootFactoryUrl() string {
+	if x != nil {
+		return x.BootFactoryUrl
+	}
+	return ""
 }
 
 type ServiceSpec_Health struct {
@@ -756,10 +776,11 @@ const file_specs_specs_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"G\n" +
 	"\vVersionSpec\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\tR\x05value\x12\"\n" +
-	"\farchitecture\x18\x02 \x01(\tR\farchitecture\"C\n" +
+	"\farchitecture\x18\x02 \x01(\tR\farchitecture\"W\n" +
 	"\tImageSpec\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x1c\n" +
-	"\tschematic\x18\x02 \x01(\tR\tschematic\"=\n" +
+	"\tschematic\x18\x02 \x01(\tR\tschematic\x12\x12\n" +
+	"\x04host\x18\x03 \x01(\tR\x04host\"=\n" +
 	"\x0fCachedImageSpec\x12\x16\n" +
 	"\x06digest\x18\x01 \x01(\tR\x06digest\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\"\x88\x02\n" +
@@ -781,7 +802,7 @@ const file_specs_specs_proto_rawDesc = "" +
 	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x12\n" +
 	"\x04uuid\x18\x02 \x01(\tR\x04uuid\x12\x1c\n" +
 	"\tschematic\x18\x03 \x01(\tR\tschematic\x12#\n" +
-	"\rtalos_version\x18\x04 \x01(\tR\ftalosVersion\"\xc6\x01\n" +
+	"\rtalos_version\x18\x04 \x01(\tR\ftalosVersion\"\xf0\x01\n" +
 	"\x0fMachineTaskSpec\x12\x12\n" +
 	"\x04slot\x18\x01 \x01(\x05R\x04slot\x12\x12\n" +
 	"\x04uuid\x18\x02 \x01(\tR\x04uuid\x12\x1c\n" +
@@ -789,7 +810,8 @@ const file_specs_specs_proto_rawDesc = "" +
 	"\rtalos_version\x18\x04 \x01(\tR\ftalosVersion\x12'\n" +
 	"\x0fconnection_args\x18\x05 \x01(\tR\x0econnectionArgs\x12\x1f\n" +
 	"\vsecure_boot\x18\x06 \x01(\bR\n" +
-	"secureBootB(Z&github.com/siderolabs/talemu/api/specsb\x06proto3"
+	"secureBoot\x12(\n" +
+	"\x10boot_factory_url\x18\a \x01(\tR\x0ebootFactoryUrlB(Z&github.com/siderolabs/talemu/api/specsb\x06proto3"
 
 var (
 	file_specs_specs_proto_rawDescOnce sync.Once

--- a/api/specs/specs.proto
+++ b/api/specs/specs.proto
@@ -34,10 +34,13 @@ message VersionSpec {
   string architecture = 2;
 }
 
-// ImageSpec is the last image used in the upgrade request.
+// ImageSpec is the current emulated Talos image, written by config-apply installs and the
+// install/upgrade APIs.
 message ImageSpec {
   string version = 1;
   string schematic = 2;
+  // Host is the registry host of the image ref, empty when the ref carries no host.
+  string host = 3;
 }
 
 // CachedImageSpec is the image pulled by the ImagePull API.
@@ -84,4 +87,7 @@ message MachineTaskSpec {
   string talos_version = 4;
   string connection_args = 5;
   bool secure_boot = 6;
+  // BootFactoryUrl is the base URL of the image factory the machine's boot media is pretended
+  // to come from, empty to use the provider's configured factory.
+  string boot_factory_url = 7;
 }

--- a/api/specs/specs_vtproto.pb.go
+++ b/api/specs/specs_vtproto.pb.go
@@ -124,6 +124,7 @@ func (m *ImageSpec) CloneVT() *ImageSpec {
 	r := new(ImageSpec)
 	r.Version = m.Version
 	r.Schematic = m.Schematic
+	r.Host = m.Host
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -256,6 +257,7 @@ func (m *MachineTaskSpec) CloneVT() *MachineTaskSpec {
 	r.TalosVersion = m.TalosVersion
 	r.ConnectionArgs = m.ConnectionArgs
 	r.SecureBoot = m.SecureBoot
+	r.BootFactoryUrl = m.BootFactoryUrl
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -395,6 +397,9 @@ func (this *ImageSpec) EqualVT(that *ImageSpec) bool {
 		return false
 	}
 	if this.Schematic != that.Schematic {
+		return false
+	}
+	if this.Host != that.Host {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -567,6 +572,9 @@ func (this *MachineTaskSpec) EqualVT(that *MachineTaskSpec) bool {
 		return false
 	}
 	if this.SecureBoot != that.SecureBoot {
+		return false
+	}
+	if this.BootFactoryUrl != that.BootFactoryUrl {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -830,6 +838,13 @@ func (m *ImageSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Host) > 0 {
+		i -= len(m.Host)
+		copy(dAtA[i:], m.Host)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Host)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Schematic) > 0 {
 		i -= len(m.Schematic)
@@ -1185,6 +1200,13 @@ func (m *MachineTaskSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.BootFactoryUrl) > 0 {
+		i -= len(m.BootFactoryUrl)
+		copy(dAtA[i:], m.BootFactoryUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BootFactoryUrl)))
+		i--
+		dAtA[i] = 0x3a
+	}
 	if m.SecureBoot {
 		i--
 		if m.SecureBoot {
@@ -1334,6 +1356,10 @@ func (m *ImageSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.Host)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1477,6 +1503,10 @@ func (m *MachineTaskSpec) SizeVT() (n int) {
 	}
 	if m.SecureBoot {
 		n += 2
+	}
+	l = len(m.BootFactoryUrl)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2175,6 +2205,38 @@ func (m *ImageSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Schematic = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Host = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3110,6 +3172,38 @@ func (m *MachineTaskSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.SecureBoot = bool(v != 0)
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BootFactoryUrl", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BootFactoryUrl = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/cmd/talemu-infra-provider/main.go
+++ b/cmd/talemu-infra-provider/main.go
@@ -34,6 +34,7 @@ import (
 
 	emuconst "github.com/siderolabs/talemu/internal/pkg/constants"
 	emuruntime "github.com/siderolabs/talemu/internal/pkg/emu"
+	"github.com/siderolabs/talemu/internal/pkg/factory"
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
 	"github.com/siderolabs/talemu/internal/pkg/machine/network"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime"
@@ -153,7 +154,11 @@ var rootCmd = &cobra.Command{
 			imageFactoryBaseURL = emuconst.DefaultImageFactoryBaseURL
 		}
 
-		schematicService, err := schematic.NewService(cfg.schematicCacheDir, imageFactoryBaseURL, logger.With(zap.String("component", "schematic_service")))
+		schematicService, err := schematic.NewService(
+			cfg.schematicCacheDir, imageFactoryBaseURL,
+			os.Getenv(emuconst.ImageFactoryUsernameEnv), os.Getenv(emuconst.ImageFactoryPasswordEnv),
+			logger.With(zap.String("component", "schematic_service")),
+		)
 		if err != nil {
 			return err
 		}
@@ -168,7 +173,9 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("image factory URL %q has no host", imageFactoryBaseURL)
 		}
 
-		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService, imageFactoryHost, cfg.nodeProxyingDisabled); err != nil {
+		enterpriseChecker := factory.NewEnterpriseChecker()
+
+		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService, enterpriseChecker, imageFactoryBaseURL, cfg.nodeProxyingDisabled); err != nil {
 			return err
 		}
 

--- a/cmd/talemu/main.go
+++ b/cmd/talemu/main.go
@@ -25,6 +25,7 @@ import (
 
 	emuconst "github.com/siderolabs/talemu/internal/pkg/constants"
 	emuruntime "github.com/siderolabs/talemu/internal/pkg/emu"
+	"github.com/siderolabs/talemu/internal/pkg/factory"
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
 	"github.com/siderolabs/talemu/internal/pkg/machine"
 	"github.com/siderolabs/talemu/internal/pkg/machine/network"
@@ -96,7 +97,11 @@ var rootCmd = &cobra.Command{
 
 		defer nc.Close() //nolint:errcheck
 
-		schematicService, err := schematicsvc.NewService(cfg.schematicCacheDir, cfg.imageFactoryBaseURL, logger.With(zap.String("component", "schematic_service")))
+		schematicService, err := schematicsvc.NewService(
+			cfg.schematicCacheDir, cfg.imageFactoryBaseURL,
+			os.Getenv(emuconst.ImageFactoryUsernameEnv), os.Getenv(emuconst.ImageFactoryPasswordEnv),
+			logger.With(zap.String("component", "schematic_service")),
+		)
 		if err != nil {
 			return err
 		}
@@ -116,8 +121,10 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		enterpriseChecker := factory.NewEnterpriseChecker()
+
 		for i := range cfg.machinesCount {
-			m, err := machine.NewMachine(fmt.Sprintf("%04d1802-c798-4da7-a410-f09abb48c8d8", i+1000), logger, emulatorState, schematicService, imageFactoryHost)
+			m, err := machine.NewMachine(fmt.Sprintf("%04d1802-c798-4da7-a410-f09abb48c8d8", i+1000), logger, emulatorState, schematicService, enterpriseChecker, cfg.imageFactoryBaseURL)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -22,3 +22,11 @@ const DefaultImageFactoryBaseURL = "https://factory.talos.dev"
 
 // OfficialExtensionPrefix is the prefix for official extensions.
 const OfficialExtensionPrefix = "siderolabs/"
+
+// ImageFactoryUsernameEnv is the environment variable carrying the optional basic auth username
+// for the image factory, needed for schematic reads against an enterprise image factory.
+const ImageFactoryUsernameEnv = "TALEMU_IMAGE_FACTORY_USERNAME"
+
+// ImageFactoryPasswordEnv is the environment variable carrying the optional basic auth password
+// for the image factory.
+const ImageFactoryPasswordEnv = "TALEMU_IMAGE_FACTORY_PASSWORD"

--- a/internal/pkg/factory/enterprise.go
+++ b/internal/pkg/factory/enterprise.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package factory implements image factory introspection helpers.
+package factory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// EnterpriseChecker detects whether an image factory is an enterprise instance.
+//
+// An enterprise image factory identifies itself via the Server response header on every response,
+// including unauthenticated ones, which is also how Omni detects it.
+type EnterpriseChecker struct {
+	client *http.Client
+	cache  map[string]bool
+
+	mu sync.Mutex
+}
+
+// NewEnterpriseChecker creates a new EnterpriseChecker.
+func NewEnterpriseChecker() *EnterpriseChecker {
+	return &EnterpriseChecker{
+		client: &http.Client{Timeout: 15 * time.Second},
+		cache:  map[string]bool{},
+	}
+}
+
+// IsEnterprise reports whether the image factory at the given base URL is an enterprise instance.
+//
+// An empty base URL means no factory and reports false without any request. Any received response
+// is cached per base URL whatever its status code, as a factory does not change its identity, and
+// even an error response carries the identifying header. Transport errors are returned and not
+// cached, so a transient network failure does not stick.
+//
+// The lock only guards the cache, never the probe itself, so one unresponsive factory cannot
+// stall lookups of the others. Concurrent probes of the same base URL are possible and harmless.
+func (checker *EnterpriseChecker) IsEnterprise(ctx context.Context, baseURL string) (bool, error) {
+	if baseURL == "" {
+		return false, nil
+	}
+
+	checker.mu.Lock()
+	enterprise, ok := checker.cache[baseURL]
+	checker.mu.Unlock()
+
+	if ok {
+		return enterprise, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(baseURL, "/")+"/versions", nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to build image factory request for %q: %w", baseURL, err)
+	}
+
+	resp, err := checker.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to probe image factory %q: %w", baseURL, err)
+	}
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	enterprise = strings.Contains(resp.Header.Get("Server"), "Enterprise")
+
+	checker.mu.Lock()
+	checker.cache[baseURL] = enterprise
+	checker.mu.Unlock()
+
+	return enterprise, nil
+}

--- a/internal/pkg/factory/enterprise_test.go
+++ b/internal/pkg/factory/enterprise_test.go
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package factory_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talemu/internal/pkg/factory"
+)
+
+func TestEnterpriseChecker(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	var enterpriseRequests, communityRequests, notFoundRequests atomic.Int32
+
+	enterprise := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		enterpriseRequests.Add(1)
+
+		w.Header().Set("Server", "Image Factory Enterprise v1.3.3")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(enterprise.Close)
+
+	community := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		communityRequests.Add(1)
+
+		w.Header().Set("Server", "Image Factory v1.3.3")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(community.Close)
+
+	// a plain registry answering 404 without the enterprise marker
+	notFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		notFoundRequests.Add(1)
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(notFound.Close)
+
+	checker := factory.NewEnterpriseChecker()
+
+	// empty base URL means no factory, no request
+	isEnterprise, err := checker.IsEnterprise(ctx, "")
+	require.NoError(t, err)
+	assert.False(t, isEnterprise)
+
+	for range 3 {
+		isEnterprise, err = checker.IsEnterprise(ctx, enterprise.URL)
+		require.NoError(t, err)
+		assert.True(t, isEnterprise)
+
+		isEnterprise, err = checker.IsEnterprise(ctx, community.URL)
+		require.NoError(t, err)
+		assert.False(t, isEnterprise)
+
+		isEnterprise, err = checker.IsEnterprise(ctx, notFound.URL)
+		require.NoError(t, err)
+		assert.False(t, isEnterprise)
+	}
+
+	// every answer is cached, whatever the status code
+	assert.EqualValues(t, 1, enterpriseRequests.Load())
+	assert.EqualValues(t, 1, communityRequests.Load())
+	assert.EqualValues(t, 1, notFoundRequests.Load())
+
+	// transport errors are returned and not cached
+	broken := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	broken.Close()
+
+	_, err = checker.IsEnterprise(ctx, broken.URL)
+	require.Error(t, err)
+
+	_, err = checker.IsEnterprise(ctx, broken.URL)
+	require.Error(t, err)
+}

--- a/internal/pkg/machine/controllers/identity_test.go
+++ b/internal/pkg/machine/controllers/identity_test.go
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cosiruntime "github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	configv1alpha1 "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+const (
+	communityFactoryHost  = "factory.talos.dev"
+	enterpriseFactoryHost = "factory-enterprise.staging.talos.dev"
+)
+
+type fakeChecker struct{}
+
+func (fakeChecker) IsEnterprise(_ context.Context, baseURL string) (bool, error) {
+	return baseURL == "https://"+enterpriseFactoryHost, nil
+}
+
+type failingChecker struct{}
+
+func (failingChecker) IsEnterprise(context.Context, string) (bool, error) {
+	return false, errors.New("the factory is unreachable")
+}
+
+// TestMachineIdentityFollowsImage drives the version and security state controllers through the
+// boot -> install -> upgrade transitions and verifies that the reported version name and FIPS
+// state follow the image source, both ways.
+func TestMachineIdentityFollowsImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	// the security state is seeded unowned at machine startup, carrying the static secure boot
+	// properties, exactly like the machine does
+	securityState := runtime.NewSecurityStateSpec(runtime.NamespaceName)
+	securityState.TypedSpec().SecureBoot = true
+	securityState.TypedSpec().BootedWithUKI = true
+	require.NoError(t, st.Create(ctx, securityState))
+
+	// the seeded boot media image: an enterprise boot ISO
+	bootImage := talos.NewImage(talos.NamespaceName, talos.ImageID)
+	bootImage.TypedSpec().Value.Version = "v1.13.6"
+	bootImage.TypedSpec().Value.Host = enterpriseFactoryHost
+	require.NoError(t, st.Create(ctx, bootImage))
+
+	rt, err := cosiruntime.NewRuntime(st, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.RegisterController(&controllers.VersionController{
+		Checker:          fakeChecker{},
+		ImageFactoryHost: communityFactoryHost,
+		BootFactoryURL:   "https://" + enterpriseFactoryHost,
+	}))
+	require.NoError(t, rt.RegisterController(&controllers.SecurityStateController{
+		Checker:          fakeChecker{},
+		ImageFactoryHost: communityFactoryHost,
+		BootFactoryURL:   "https://" + enterpriseFactoryHost,
+	}))
+
+	runtimeCtx, stopRuntime := context.WithCancel(ctx)
+
+	var eg errgroup.Group
+
+	eg.Go(func() error { return rt.Run(runtimeCtx) })
+
+	t.Cleanup(func() {
+		stopRuntime()
+
+		require.NoError(t, eg.Wait())
+	})
+
+	// enterprise boot media: enterprise name, FIPS enabled, secure boot untouched
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos Enterprise", res.TypedSpec().Name)
+		a.Equal("v1.13.6", res.TypedSpec().Version)
+	})
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateEnabled, res.TypedSpec().FIPSState)
+		a.True(res.TypedSpec().SecureBoot)
+	})
+
+	// the strict kernel argument flips FIPS to strict
+	cmdline := runtime.NewKernelCmdline()
+	cmdline.TypedSpec().Cmdline = "talos.platform=metal talos.fips140=strict"
+	require.NoError(t, st.Create(ctx, cmdline))
+
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateStrict, res.TypedSpec().FIPSState)
+	})
+
+	// an upgrade to a community factory image flips the identity back
+	_, err = safe.StateUpdateWithConflicts(ctx, st, bootImage.Metadata(), func(res *talos.Image) error {
+		res.TypedSpec().Value.Host = communityFactoryHost
+		res.TypedSpec().Value.Version = "v1.14.0"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos", res.TypedSpec().Name)
+		a.Equal("v1.14.0", res.TypedSpec().Version)
+	})
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateDisabled, res.TypedSpec().FIPSState)
+		a.True(res.TypedSpec().SecureBoot, "secure boot is a firmware property and never follows the image")
+	})
+}
+
+// TestMachineIdentityCheckerFailure verifies that a broken image factory probe neither blocks the
+// boot-readiness version write nor leaves the machine without a reported name: the internal
+// version is written, and the version name falls back to the community one.
+func TestMachineIdentityCheckerFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	securityState := runtime.NewSecurityStateSpec(runtime.NamespaceName)
+	require.NoError(t, st.Create(ctx, securityState))
+
+	rt, err := cosiruntime.NewRuntime(st, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.RegisterController(&controllers.VersionController{
+		Checker:          failingChecker{},
+		ImageFactoryHost: communityFactoryHost,
+		BootFactoryURL:   "https://" + enterpriseFactoryHost,
+	}))
+
+	runtimeCtx, stopRuntime := context.WithCancel(ctx)
+
+	var eg errgroup.Group
+
+	eg.Go(func() error { return rt.Run(runtimeCtx) })
+
+	t.Cleanup(func() {
+		stopRuntime()
+
+		require.NoError(t, eg.Wait())
+	})
+
+	// the boot-readiness gating version resource is written despite the probe failures
+	rtestutils.AssertResource(ctx, t, st, talos.VersionID, func(res *talos.Version, a *assert.Assertions) {
+		a.NotEmpty(res.TypedSpec().Value.Value)
+	})
+
+	// the version name falls back to the community one instead of staying absent
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos", res.TypedSpec().Name)
+	})
+}
+
+// TestMachineIdentityConfigInstall verifies the config-apply install path: a maintenance machine
+// with no image state takes its identity from the boot factory, and applying a config with a
+// community install image flips it to community even though the boot factory is enterprise.
+func TestMachineIdentityConfigInstall(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	securityState := runtime.NewSecurityStateSpec(runtime.NamespaceName)
+	require.NoError(t, st.Create(ctx, securityState))
+
+	rt, err := cosiruntime.NewRuntime(st, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.RegisterController(&controllers.VersionController{
+		Checker:          fakeChecker{},
+		ImageFactoryHost: communityFactoryHost,
+		BootFactoryURL:   "https://" + enterpriseFactoryHost,
+	}))
+	require.NoError(t, rt.RegisterController(&controllers.SecurityStateController{
+		Checker:          fakeChecker{},
+		ImageFactoryHost: communityFactoryHost,
+		BootFactoryURL:   "https://" + enterpriseFactoryHost,
+	}))
+
+	runtimeCtx, stopRuntime := context.WithCancel(ctx)
+
+	var eg errgroup.Group
+
+	eg.Go(func() error { return rt.Run(runtimeCtx) })
+
+	t.Cleanup(func() {
+		stopRuntime()
+
+		require.NoError(t, eg.Wait())
+	})
+
+	// nothing installed, no config: the boot media identity wins
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos Enterprise", res.TypedSpec().Name)
+	})
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateEnabled, res.TypedSpec().FIPSState)
+	})
+
+	// a config-apply install with a community image flips the machine to community
+	provider, err := container.New(&configv1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &configv1alpha1.MachineConfig{
+			MachineInstall: &configv1alpha1.InstallConfig{
+				InstallImage: "ghcr.io/siderolabs/installer:v1.13.6",
+			},
+		},
+		ClusterConfig: &configv1alpha1.ClusterConfig{},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, st.Create(ctx, config.NewMachineConfigWithID(provider, config.ActiveID)))
+
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos", res.TypedSpec().Name)
+	})
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateDisabled, res.TypedSpec().FIPSState)
+	})
+}

--- a/internal/pkg/machine/controllers/image_source.go
+++ b/internal/pkg/machine/controllers/image_source.go
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+// EnterpriseChecker detects whether an image factory is an enterprise instance.
+type EnterpriseChecker interface {
+	IsEnterprise(ctx context.Context, baseURL string) (bool, error)
+}
+
+// resolveImageSourceURL returns the base URL of the image factory the machine's current Talos
+// image comes from, or an empty string when the image is not a factory one (a community build).
+//
+// The precedence follows the resource state, not value emptiness: the installed image decides if
+// it exists, then the config install image, and only a machine with neither (maintenance mode,
+// nothing installed) takes the boot media identity. An image ref without a host, as well as an
+// unparseable one, resolves to community.
+func resolveImageSourceURL(image *talos.Image, cfg *config.MachineConfig, imageFactoryHost, bootFactoryURL string) string {
+	switch {
+	case image != nil:
+		return factoryURLForHost(image.TypedSpec().Value.Host, bootFactoryURL)
+	case cfg != nil:
+		installImage := cfg.Container().RawV1Alpha1().Machine().Install().Image()
+		if installImage == "" {
+			return ""
+		}
+
+		parsed, err := talos.ParseImageRef(imageFactoryHost, installImage)
+		if err != nil {
+			return ""
+		}
+
+		return factoryURLForHost(parsed.Host, bootFactoryURL)
+	default:
+		return bootFactoryURL
+	}
+}
+
+// factoryURLForHost builds the base URL to probe for the given image host. Image refs carry no
+// scheme, so the URL defaults to HTTPS, except when the host is the boot factory itself: then its
+// configured base URL is used as-is, keeping a plain-HTTP boot factory working.
+func factoryURLForHost(host, bootFactoryURL string) string {
+	if host == "" {
+		return ""
+	}
+
+	if parsed, err := url.Parse(bootFactoryURL); err == nil && parsed.Host == host {
+		return bootFactoryURL
+	}
+
+	return "https://" + host
+}

--- a/internal/pkg/machine/controllers/image_source_internal_test.go
+++ b/internal/pkg/machine/controllers/image_source_internal_test.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+func TestResolveImageSourceURL(t *testing.T) {
+	t.Parallel()
+
+	const factoryHost = "factory.talos.dev"
+
+	imageWithHost := func(host string) *talos.Image {
+		image := talos.NewImage(talos.NamespaceName, talos.ImageID)
+		image.TypedSpec().Value.Host = host
+
+		return image
+	}
+
+	for _, test := range []struct { //nolint:govet
+		name           string
+		image          *talos.Image
+		bootFactoryURL string
+		expected       string
+	}{
+		{
+			name:           "no image, no config: boot factory as-is",
+			bootFactoryURL: "http://factory.local:8080",
+			expected:       "http://factory.local:8080",
+		},
+		{
+			name:           "image from a foreign factory",
+			image:          imageWithHost("factory-enterprise.staging.talos.dev"),
+			bootFactoryURL: "https://factory.talos.dev",
+			expected:       "https://factory-enterprise.staging.talos.dev",
+		},
+		{
+			name:           "image host matching the boot factory keeps its scheme",
+			image:          imageWithHost("factory.local:8080"),
+			bootFactoryURL: "http://factory.local:8080",
+			expected:       "http://factory.local:8080",
+		},
+		{
+			name:           "image without a host is community",
+			image:          imageWithHost(""),
+			bootFactoryURL: "https://factory.talos.dev",
+			expected:       "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, resolveImageSourceURL(test.image, nil, factoryHost, test.bootFactoryURL))
+		})
+	}
+}

--- a/internal/pkg/machine/controllers/machine_status.go
+++ b/internal/pkg/machine/controllers/machine_status.go
@@ -250,7 +250,7 @@ func (ctrl *MachineStatusController) reconcile(ctx context.Context, r controller
 // talos.Image is owned by no controller (the services mutate it directly), so it is updated through
 // the raw state here rather than a controller output.
 func (ctrl *MachineStatusController) setInstalledImage(ctx context.Context, imageRef string) error {
-	schematic, version, err := talos.ParseImageRef(ctrl.ImageFactoryHost, imageRef)
+	parsed, err := talos.ParseImageRef(ctrl.ImageFactoryHost, imageRef)
 	if err != nil {
 		return err
 	}
@@ -258,8 +258,9 @@ func (ctrl *MachineStatusController) setInstalledImage(ctx context.Context, imag
 	return ctrl.State.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
 		value := res.(*talos.Image).TypedSpec().Value //nolint:forcetypeassert,errcheck
 
-		value.Schematic = schematic
-		value.Version = version
+		value.Schematic = parsed.Schematic
+		value.Version = parsed.Version
+		value.Host = parsed.Host
 
 		return nil
 	})

--- a/internal/pkg/machine/controllers/schematic.go
+++ b/internal/pkg/machine/controllers/schematic.go
@@ -7,7 +7,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -37,16 +36,14 @@ func readCurrentSchematicID(ctx context.Context, r controller.Runtime, imageFact
 	}
 
 	installImage := schematicContent.Container().RawV1Alpha1().Machine().Install().Image()
-	if !strings.HasPrefix(installImage, imageFactoryHost) {
+	if installImage == "" {
 		return "", nil
 	}
 
-	parts := strings.Split(installImage, "/")
-
-	schematicID, _, found := strings.Cut(parts[len(parts)-1], ":")
-	if !found {
-		return "", fmt.Errorf("failed to parse schematic id from the install image")
+	parsed, err := talos.ParseImageRef(imageFactoryHost, installImage)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse schematic id from the install image: %w", err)
 	}
 
-	return schematicID, nil
+	return parsed.Schematic, nil
 }

--- a/internal/pkg/machine/controllers/security_state.go
+++ b/internal/pkg/machine/controllers/security_state.go
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/optional"
+	"github.com/siderolabs/go-pointer"
+	"github.com/siderolabs/go-procfs/procfs"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/machineconfig"
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+// SecurityStateController keeps the FIPS state of the machine in sync with its current image
+// source: FIPS is enabled iff the image comes from an enterprise image factory, and strict
+// additionally requires the talos.fips140=strict kernel argument.
+//
+// The security state resource itself is seeded at machine startup (it carries the static secure
+// boot and UKI properties, and it must exist before the API serves requests), so this controller
+// only updates the FIPS state field, without taking ownership.
+type SecurityStateController struct {
+	// Checker detects whether the current image source is an enterprise image factory.
+	Checker EnterpriseChecker
+
+	// ImageFactoryHost is the host of the configured image factory.
+	ImageFactoryHost string
+
+	// BootFactoryURL is the base URL of the image factory the boot media is pretended to come
+	// from, deciding the machine identity before anything is installed.
+	BootFactoryURL string
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *SecurityStateController) Name() string {
+	return "runtime.SecurityStateController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *SecurityStateController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        optional.Some(config.ActiveID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: talos.NamespaceName,
+			Type:      talos.ImageType,
+			ID:        optional.Some(talos.ImageID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: runtime.NamespaceName,
+			Type:      runtime.KernelCmdlineType,
+			ID:        optional.Some(runtime.KernelCmdlineID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *SecurityStateController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: runtime.SecurityStateType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+func (ctrl *SecurityStateController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		config, err := machineconfig.GetComplete(ctx, r)
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		image, err := safe.ReaderGetByID[*talos.Image](ctx, r, talos.ImageID)
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		cmdline, err := safe.ReaderGetByID[*runtime.KernelCmdline](ctx, r, runtime.KernelCmdlineID)
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		// on a probe failure the previously written state (or the seeded community default) stays
+		// published, the error only arranges the backoff retry
+		enterprise, err := ctrl.Checker.IsEnterprise(ctx, resolveImageSourceURL(image, config, ctrl.ImageFactoryHost, ctrl.BootFactoryURL))
+		if err != nil {
+			logger.Warn("failed to determine the image factory kind, keeping the previously reported FIPS state", zap.Error(err))
+
+			return err
+		}
+
+		fipsState := runtime.FIPSStateDisabled
+
+		if enterprise {
+			fipsState = runtime.FIPSStateEnabled
+
+			if cmdline != nil && cmdlineHasStrictFIPS(cmdline.TypedSpec().Cmdline) {
+				fipsState = runtime.FIPSStateStrict
+			}
+		}
+
+		if err = safe.WriterModify(ctx, r, runtime.NewSecurityStateSpec(runtime.NamespaceName), func(res *runtime.SecurityState) error {
+			res.TypedSpec().FIPSState = fipsState
+
+			return nil
+		}, controller.WithModifyNoOwner()); err != nil {
+			return err
+		}
+	}
+}
+
+// cmdlineHasStrictFIPS reports whether the kernel command line opts into the strict FIPS mode,
+// the same way Talos reads it: the first talos.fips140 argument with the value "strict".
+func cmdlineHasStrictFIPS(cmdline string) bool {
+	value := procfs.NewCmdline(cmdline).Get("talos.fips140").First()
+
+	return pointer.SafeDeref(value) == "strict"
+}

--- a/internal/pkg/machine/controllers/version.go
+++ b/internal/pkg/machine/controllers/version.go
@@ -6,7 +6,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -15,15 +14,27 @@ import (
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/talemu/internal/pkg/machine/machineconfig"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
 )
 
-// VersionController computes extensions list from the configuration.
-// Updates machine status resource.
-type VersionController struct{}
+// VersionController computes the current Talos version and version name of the machine from its
+// current image source.
+type VersionController struct {
+	// Checker detects whether the current image source is an enterprise image factory.
+	Checker EnterpriseChecker
+
+	// ImageFactoryHost is the host of the configured image factory, used to recover schematic IDs
+	// from image refs.
+	ImageFactoryHost string
+
+	// BootFactoryURL is the base URL of the image factory the boot media is pretended to come
+	// from, deciding the machine identity before anything is installed.
+	BootFactoryURL string
+}
 
 // Name implements controller.Controller interface.
 func (ctrl *VersionController) Name() string {
@@ -55,6 +66,10 @@ func (ctrl *VersionController) Outputs() []controller.Output {
 			Type: talos.VersionType,
 			Kind: controller.OutputExclusive,
 		},
+		{
+			Type: runtime.VersionType,
+			Kind: controller.OutputExclusive,
+		},
 	}
 }
 
@@ -67,58 +82,100 @@ func (ctrl *VersionController) Run(ctx context.Context, r controller.Runtime, lo
 		case <-r.EventCh():
 		}
 
-		config, err := machineconfig.GetComplete(ctx, r)
-		if err != nil && !state.IsNotFoundError(err) {
-			return err
-		}
-
-		image, err := safe.ReaderGetByID[*talos.Image](ctx, r, talos.ImageID)
-		if err != nil && !state.IsNotFoundError(err) {
-			return err
-		}
-
-		var (
-			version string
-			source  string
-		)
-
-		switch {
-		case image != nil:
-			source = "upgrade"
-
-			version = image.TypedSpec().Value.Version
-		case config != nil:
-			source = "install"
-
-			var found bool
-
-			installImage := config.Container().RawV1Alpha1().Machine().Install().Image()
-
-			_, version, found = strings.Cut(installImage, ":")
-			if !found {
-				return fmt.Errorf("failed to parse schematic id from the install image")
-			}
-		}
-
-		if version == "" {
-			version = "v" + constants.DefaultTalosVersion
-		}
-
-		if err := safe.WriterModify(ctx, r, talos.NewVersion(talos.NamespaceName, talos.VersionID), func(res *talos.Version) error {
-			if version != res.TypedSpec().Value.Value {
-				logger.Info("version updated", zap.String("source", source))
-			}
-
-			if !strings.HasPrefix(version, "v") {
-				version = "v" + version
-			}
-
-			res.TypedSpec().Value.Value = version
-			res.TypedSpec().Value.Architecture = "amd64"
-
-			return nil
-		}); err != nil {
+		if err := ctrl.reconcile(ctx, r, logger); err != nil {
 			return err
 		}
 	}
+}
+
+func (ctrl *VersionController) reconcile(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	config, err := machineconfig.GetComplete(ctx, r)
+	if err != nil && !state.IsNotFoundError(err) {
+		return err
+	}
+
+	image, err := safe.ReaderGetByID[*talos.Image](ctx, r, talos.ImageID)
+	if err != nil && !state.IsNotFoundError(err) {
+		return err
+	}
+
+	var (
+		version string
+		source  string
+	)
+
+	switch {
+	case image != nil:
+		source = "upgrade"
+
+		version = image.TypedSpec().Value.Version
+	case config != nil:
+		source = "install"
+
+		installImage := config.Container().RawV1Alpha1().Machine().Install().Image()
+
+		// an empty or unparseable install image falls back to the default version instead of
+		// erroring, as this write gates the machine boot readiness
+		if parsed, parseErr := talos.ParseImageRef(ctrl.ImageFactoryHost, installImage); parseErr == nil {
+			version = parsed.Version
+		} else {
+			logger.Warn("failed to parse the install image, using the default version", zap.Error(parseErr))
+		}
+	}
+
+	if version == "" {
+		version = "v" + constants.DefaultTalosVersion
+	}
+
+	// this write gates the machine boot readiness, so it happens first and never depends on
+	// the image factory probe below
+	if err = safe.WriterModify(ctx, r, talos.NewVersion(talos.NamespaceName, talos.VersionID), func(res *talos.Version) error {
+		if version != res.TypedSpec().Value.Value {
+			logger.Info("version updated", zap.String("source", source))
+		}
+
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+
+		res.TypedSpec().Value.Value = version
+		res.TypedSpec().Value.Architecture = "amd64"
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	enterprise, checkErr := ctrl.Checker.IsEnterprise(ctx, resolveImageSourceURL(image, config, ctrl.ImageFactoryHost, ctrl.BootFactoryURL))
+	if checkErr != nil {
+		logger.Warn("failed to determine the image factory kind, keeping the previously reported name", zap.Error(checkErr))
+	}
+
+	if err = safe.WriterModify(ctx, r, runtime.NewVersion(), func(res *runtime.Version) error {
+		name := res.TypedSpec().Name
+
+		switch {
+		case checkErr == nil && enterprise:
+			name = "Talos Enterprise"
+		case checkErr == nil:
+			name = "Talos"
+		case name == "":
+			// nothing reported yet, publish the community fallback rather than nothing
+			name = "Talos"
+		}
+
+		if name != res.TypedSpec().Name && res.TypedSpec().Name != "" {
+			logger.Info("version name updated", zap.String("name", name))
+		}
+
+		res.TypedSpec().Name = name
+		res.TypedSpec().Version = version
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// the fallback state is published above, the error only arranges the backoff retry
+	return checkErr
 }

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"net/url"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -51,24 +52,30 @@ const (
 
 // Machine is a single Talos machine.
 type Machine struct {
-	globalState      state.State
-	runtime          *truntime.Runtime
-	logger           *zap.Logger
-	shutdown         chan struct{}
-	schematicService *schematic.Service
-	imageFactoryHost string
-	uuid             string
+	globalState       state.State
+	runtime           *truntime.Runtime
+	logger            *zap.Logger
+	shutdown          chan struct{}
+	schematicService  *schematic.Service
+	enterpriseChecker controllers.EnterpriseChecker
+
+	// imageFactoryBaseURL is the base URL of the configured image factory, scheme included.
+	imageFactoryBaseURL string
+	uuid                string
 }
 
 // NewMachine creates a Machine.
-func NewMachine(uuid string, logger *zap.Logger, globalState state.State, schematicService *schematic.Service, imageFactoryHost string) (*Machine, error) {
+func NewMachine(uuid string, logger *zap.Logger, globalState state.State, schematicService *schematic.Service,
+	enterpriseChecker controllers.EnterpriseChecker, imageFactoryBaseURL string,
+) (*Machine, error) {
 	return &Machine{
-		uuid:             uuid,
-		logger:           logger,
-		globalState:      globalState,
-		schematicService: schematicService,
-		imageFactoryHost: imageFactoryHost,
-		shutdown:         make(chan struct{}, 1),
+		uuid:                uuid,
+		logger:              logger,
+		globalState:         globalState,
+		schematicService:    schematicService,
+		enterpriseChecker:   enterpriseChecker,
+		imageFactoryBaseURL: imageFactoryBaseURL,
+		shutdown:            make(chan struct{}, 1),
 	}, nil
 }
 
@@ -109,10 +116,21 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 	m.logger = zap.New(core).With(zap.String("machine", machineID), zap.String("uuid", m.uuid))
 
+	imageFactoryHost, err := hostOfURL(m.imageFactoryBaseURL)
+	if err != nil {
+		return err
+	}
+
+	// the configured base URL is used as-is, so a plain-HTTP factory keeps working
+	bootFactoryURL := opts.bootFactoryURL
+	if bootFactoryURL == "" {
+		bootFactoryURL = m.imageFactoryBaseURL
+	}
+
 	rt, err := truntime.NewRuntime(
 		ctx, m.logger, slot, machineID, m.globalState,
 		kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService,
-		m.imageFactoryHost, opts.nodeProxyingDisabled,
+		m.enterpriseChecker, imageFactoryHost, bootFactoryURL, opts.nodeProxyingDisabled,
 	)
 	if err != nil {
 		return fmt.Errorf("COSI runtime creation failed: %w", err)
@@ -324,6 +342,18 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 		image.TypedSpec().Value.Schematic = opts.schematic
 		image.TypedSpec().Value.Version = opts.talosVersion
 
+		// the seeded image is the boot media, so it carries the boot factory host, making the
+		// machine identity (enterprise-ness, FIPS state) follow the boot media until an
+		// install/upgrade overwrites the image
+		var bootFactoryHost string
+
+		bootFactoryHost, err = hostOfURL(bootFactoryURL)
+		if err != nil {
+			return err
+		}
+
+		image.TypedSpec().Value.Host = bootFactoryHost
+
 		resources = append(resources, image)
 	}
 
@@ -405,4 +435,14 @@ func (m *Machine) Cleanup(ctx context.Context) error {
 
 		return conn.Link.Delete(existing.Index)
 	})
+}
+
+// hostOfURL extracts the host part of a base URL.
+func hostOfURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL %q: %w", rawURL, err)
+	}
+
+	return parsed.Host, nil
 }

--- a/internal/pkg/machine/options.go
+++ b/internal/pkg/machine/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	nc                   *network.Client
 	talosVersion         string
 	schematic            string
+	bootFactoryURL       string
 	secureBoot           bool
 	nodeProxyingDisabled bool
 }
@@ -60,5 +61,13 @@ func WithSecureBoot(value bool) Option {
 func WithNodeProxyingDisabled(value bool) Option {
 	return func(o *Options) {
 		o.nodeProxyingDisabled = value
+	}
+}
+
+// WithBootFactoryURL sets the base URL of the image factory the machine's boot media is
+// pretended to come from. Empty means the configured image factory.
+func WithBootFactoryURL(value string) Option {
+	return func(o *Options) {
+		o.bootFactoryURL = value
 	}
 }

--- a/internal/pkg/machine/runtime/resources/talos/image.go
+++ b/internal/pkg/machine/runtime/resources/talos/image.go
@@ -24,10 +24,25 @@ func NewImage(ns, id string) *Image {
 	)
 }
 
-// ParseImageRef splits an installer image reference into its schematic id and Talos version.
-// The schematic is only recoverable when the reference points at the image factory host, since
-// only those references carry it as the repository path segment.
-func ParseImageRef(imageFactoryHost, imageRef string) (schematic, version string, err error) {
+// ImageRef is the parsed form of an installer image reference.
+type ImageRef struct {
+	// Host is the registry host of the reference. Real install images are pulled via containerd,
+	// which requires fully qualified references, so the first path component is the host. It is
+	// only empty for a single-component reference, which cannot reach a real machine.
+	Host string
+
+	// Schematic is the image factory schematic ID. It is only recoverable when the reference
+	// points at the image factory host, since only those references carry it as the repository
+	// path segment.
+	Schematic string
+
+	// Version is the image tag.
+	Version string
+}
+
+// ParseImageRef splits an installer image reference into its registry host, schematic id and
+// Talos version.
+func ParseImageRef(imageFactoryHost, imageRef string) (ImageRef, error) {
 	ref := imageRef
 
 	if at := strings.IndexByte(ref, '@'); at != -1 {
@@ -38,14 +53,22 @@ func ParseImageRef(imageFactoryHost, imageRef string) (schematic, version string
 
 	schematicCandidate, version, found := strings.Cut(parts[len(parts)-1], ":")
 	if !found {
-		return "", "", fmt.Errorf("failed to parse the image %q", imageRef)
+		return ImageRef{}, fmt.Errorf("failed to parse the image %q", imageRef)
 	}
 
-	if parts[0] == imageFactoryHost {
-		schematic = schematicCandidate
+	parsed := ImageRef{
+		Version: version,
 	}
 
-	return schematic, version, nil
+	if len(parts) > 1 {
+		parsed.Host = parts[0]
+	}
+
+	if parsed.Host != "" && parsed.Host == imageFactoryHost {
+		parsed.Schematic = schematicCandidate
+	}
+
+	return parsed, nil
 }
 
 const (

--- a/internal/pkg/machine/runtime/resources/talos/image_test.go
+++ b/internal/pkg/machine/runtime/resources/talos/image_test.go
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+func TestParseImageRef(t *testing.T) {
+	t.Parallel()
+
+	const factoryHost = "factory.talos.dev"
+
+	for _, test := range []struct { //nolint:govet
+		name     string
+		ref      string
+		expected talos.ImageRef
+		wantErr  bool
+	}{
+		{
+			name: "factory installer",
+			ref:  "factory.talos.dev/metal-installer/abcd1234:v1.13.6",
+			expected: talos.ImageRef{
+				Host:      "factory.talos.dev",
+				Schematic: "abcd1234",
+				Version:   "v1.13.6",
+			},
+		},
+		{
+			name: "factory installer with digest",
+			ref:  "factory.talos.dev/metal-installer/abcd1234:v1.13.6@sha256:deadbeef",
+			expected: talos.ImageRef{
+				Host:      "factory.talos.dev",
+				Schematic: "abcd1234",
+				Version:   "v1.13.6",
+			},
+		},
+		{
+			name: "foreign factory keeps host, drops schematic",
+			ref:  "factory-enterprise.staging.talos.dev/metal-installer/abcd1234:v1.13.6",
+			expected: talos.ImageRef{
+				Host:    "factory-enterprise.staging.talos.dev",
+				Version: "v1.13.6",
+			},
+		},
+		{
+			name: "plain registry image",
+			ref:  "ghcr.io/siderolabs/installer:v1.13.6",
+			expected: talos.ImageRef{
+				Host:    "ghcr.io",
+				Version: "v1.13.6",
+			},
+		},
+		{
+			name: "registry with port",
+			ref:  "localhost:5000/siderolabs/installer:v1.13.6",
+			expected: talos.ImageRef{
+				Host:    "localhost:5000",
+				Version: "v1.13.6",
+			},
+		},
+		{
+			name: "single component ref has no host",
+			ref:  "installer:v1.13.6",
+			expected: talos.ImageRef{
+				Version: "v1.13.6",
+			},
+		},
+		{
+			name:    "no tag",
+			ref:     "ghcr.io/siderolabs/installer",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := talos.ParseImageRef(factoryHost, test.ref)
+			if test.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, parsed)
+		})
+	}
+}

--- a/internal/pkg/machine/runtime/resources/talos/talos.go
+++ b/internal/pkg/machine/runtime/resources/talos/talos.go
@@ -171,6 +171,7 @@ func Register(ctx context.Context, state state.State) error {
 		&runtime.MountStatus{},
 		&runtime.PlatformMetadata{},
 		&runtime.SecurityState{},
+		&runtime.Version{},
 		&secrets.API{},
 		&secrets.CertSAN{},
 		&secrets.Etcd{},

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -43,7 +43,7 @@ type Runtime struct {
 // NewRuntime creates new runtime.
 func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, globalState state.State,
 	kubernetes *kubefactory.Kubernetes, nc *network.Client, logSink *logging.ZapCore, baseKernelArgs string, schematicService *schematic.Service,
-	imageFactoryHost string, nodeProxyingDisabled bool,
+	enterpriseChecker controllers.EnterpriseChecker, imageFactoryHost, bootFactoryURL string, nodeProxyingDisabled bool,
 ) (*Runtime, error) {
 	stateDir := GetStateDir(id)
 
@@ -117,7 +117,16 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 			ImageFactoryHost: imageFactoryHost,
 		},
 		&controllers.MachineStatusController{State: st, ImageFactoryHost: imageFactoryHost},
-		&controllers.VersionController{},
+		&controllers.VersionController{
+			Checker:          enterpriseChecker,
+			ImageFactoryHost: imageFactoryHost,
+			BootFactoryURL:   bootFactoryURL,
+		},
+		&controllers.SecurityStateController{
+			Checker:          enterpriseChecker,
+			ImageFactoryHost: imageFactoryHost,
+			BootFactoryURL:   bootFactoryURL,
+		},
 		&controllers.NodeIdentityController{},
 		&controllers.NodenameController{},
 		&controllers.EtcdController{

--- a/internal/pkg/machine/services/image_internal_test.go
+++ b/internal/pkg/machine/services/image_internal_test.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetImage verifies that every part of the parsed image ref is recorded, and that a
+// cross-factory switch at the same version and schematic shape counts as a change, so it
+// triggers the emulated reboot.
+func TestSetImage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	const factoryHost = "factory.talos.dev"
+
+	changed, err := setImage(ctx, st, factoryHost, "factory.talos.dev/metal-installer/abcd1234:v1.13.6")
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	// same ref again: no change
+	changed, err = setImage(ctx, st, factoryHost, "factory.talos.dev/metal-installer/abcd1234:v1.13.6")
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	// same version, different factory: must count as a change
+	changed, err = setImage(ctx, st, factoryHost, "factory-enterprise.staging.talos.dev/metal-installer/abcd1234:v1.13.6")
+	require.NoError(t, err)
+	assert.True(t, changed)
+}

--- a/internal/pkg/machine/services/machined.go
+++ b/internal/pkg/machine/services/machined.go
@@ -1032,7 +1032,7 @@ func (c *MachineService) Processes(_ context.Context, _ *emptypb.Empty) (*machin
 // setImage records the target Talos image and reports whether it changed, so a redundant upgrade to
 // the running image can skip the reboot.
 func setImage(ctx context.Context, st state.State, imageFactoryHost, imageRef string) (bool, error) {
-	schematic, version, err := talos.ParseImageRef(imageFactoryHost, imageRef)
+	parsed, err := talos.ParseImageRef(imageFactoryHost, imageRef)
 	if err != nil {
 		return false, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
@@ -1043,10 +1043,14 @@ func setImage(ctx context.Context, st state.State, imageFactoryHost, imageRef st
 		typedRes := res.(*talos.Image) //nolint:forcetypeassert,errcheck
 
 		value := typedRes.TypedSpec().Value
-		changed = value.Schematic != schematic || value.Version != version
 
-		value.Schematic = schematic
-		value.Version = version
+		// the host takes part in the comparison, as the same version/schematic served by a different
+		// factory is a different build (e.g. an enterprise one), and the change must cause a reboot
+		changed = value.Schematic != parsed.Schematic || value.Version != parsed.Version || value.Host != parsed.Host
+
+		value.Schematic = parsed.Schematic
+		value.Version = parsed.Version
+		value.Host = parsed.Host
 
 		return nil
 	}); err != nil {

--- a/internal/pkg/provider/controllers/machine/machine.go
+++ b/internal/pkg/provider/controllers/machine/machine.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
 	"github.com/siderolabs/talemu/internal/pkg/machine"
+	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
 	"github.com/siderolabs/talemu/internal/pkg/machine/network"
 	"github.com/siderolabs/talemu/internal/pkg/provider/resources"
 	"github.com/siderolabs/talemu/internal/pkg/schematic"
@@ -26,10 +27,11 @@ type TaskSpec struct {
 	Machine              *resources.MachineTask
 	GlobalState          state.State
 	SchematicService     *schematic.Service
+	EnterpriseChecker    controllers.EnterpriseChecker
 	Params               *machine.SideroLinkParams
 	Kubernetes           *kubefactory.Kubernetes
 	NC                   *network.Client
-	ImageFactoryHost     string
+	ImageFactoryBaseURL  string
 	NodeProxyingDisabled bool
 }
 
@@ -45,7 +47,7 @@ func (s TaskSpec) Equal(other TaskSpec) bool {
 
 // RunTask implements task.TaskSpec.
 func (s TaskSpec) RunTask(ctx context.Context, logger *zap.Logger, _ any) error {
-	m, err := machine.NewMachine(s.Machine.TypedSpec().Value.Uuid, logger, s.GlobalState, s.SchematicService, s.ImageFactoryHost)
+	m, err := machine.NewMachine(s.Machine.TypedSpec().Value.Uuid, logger, s.GlobalState, s.SchematicService, s.EnterpriseChecker, s.ImageFactoryBaseURL)
 	if err != nil {
 		return err
 	}
@@ -62,5 +64,6 @@ func (s TaskSpec) RunTask(ctx context.Context, logger *zap.Logger, _ any) error 
 		machine.WithNetworkClient(s.NC),
 		machine.WithSecureBoot(s.Machine.TypedSpec().Value.SecureBoot),
 		machine.WithNodeProxyingDisabled(s.NodeProxyingDisabled),
+		machine.WithBootFactoryURL(s.Machine.TypedSpec().Value.BootFactoryUrl),
 	)
 }

--- a/internal/pkg/provider/controllers/machine_runner.go
+++ b/internal/pkg/provider/controllers/machine_runner.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
 	"github.com/siderolabs/talemu/internal/pkg/machine"
+	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
 	"github.com/siderolabs/talemu/internal/pkg/machine/network"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/emu"
@@ -34,14 +35,16 @@ type MachineController struct {
 	nc                   *network.Client
 	globalState          state.State
 	schematicService     *schematic.Service
-	imageFactoryHost     string
+	enterpriseChecker    controllers.EnterpriseChecker
+	imageFactoryBaseURL  string
 	nodeProxyingDisabled bool
 }
 
 // NewMachineController creates new machine controller.
 func NewMachineController(
 	globalState state.State, kubernetes *kubefactory.Kubernetes, nc *network.Client,
-	schematicService *schematic.Service, imageFactoryHost string, nodeProxyingDisabled bool,
+	schematicService *schematic.Service, enterpriseChecker controllers.EnterpriseChecker,
+	imageFactoryBaseURL string, nodeProxyingDisabled bool,
 ) *MachineController {
 	return &MachineController{
 		runner:               task.NewEqualRunner[machinetask.TaskSpec](),
@@ -49,7 +52,8 @@ func NewMachineController(
 		kubernetes:           kubernetes,
 		nc:                   nc,
 		schematicService:     schematicService,
-		imageFactoryHost:     imageFactoryHost,
+		enterpriseChecker:    enterpriseChecker,
+		imageFactoryBaseURL:  imageFactoryBaseURL,
 		nodeProxyingDisabled: nodeProxyingDisabled,
 	}
 }
@@ -123,7 +127,8 @@ func (ctrl *MachineController) Run(ctx context.Context, r controller.Runtime, lo
 				Machine:              m,
 				GlobalState:          ctrl.globalState,
 				SchematicService:     ctrl.schematicService,
-				ImageFactoryHost:     ctrl.imageFactoryHost,
+				EnterpriseChecker:    ctrl.enterpriseChecker,
+				ImageFactoryBaseURL:  ctrl.imageFactoryBaseURL,
 				Kubernetes:           ctrl.kubernetes,
 				Params:               params,
 				NC:                   ctrl.nc,

--- a/internal/pkg/provider/provider.go
+++ b/internal/pkg/provider/provider.go
@@ -10,15 +10,19 @@ import (
 
 	"github.com/siderolabs/talemu/internal/pkg/emu"
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
+	machinecontrollers "github.com/siderolabs/talemu/internal/pkg/machine/controllers"
 	"github.com/siderolabs/talemu/internal/pkg/machine/network"
 	"github.com/siderolabs/talemu/internal/pkg/provider/controllers"
 	"github.com/siderolabs/talemu/internal/pkg/schematic"
 )
 
 // RegisterControllers registers additional controllers required for the infra provider.
-func RegisterControllers(runtime *emu.Runtime, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service, imageFactoryHost string, nodeProxyingDisabled bool) error {
+func RegisterControllers(
+	runtime *emu.Runtime, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service,
+	enterpriseChecker machinecontrollers.EnterpriseChecker, imageFactoryBaseURL string, nodeProxyingDisabled bool,
+) error {
 	controllers := []controller.Controller{
-		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService, imageFactoryHost, nodeProxyingDisabled),
+		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService, enterpriseChecker, imageFactoryBaseURL, nodeProxyingDisabled),
 	}
 
 	for _, ctrl := range controllers {

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -7,6 +7,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -36,8 +37,12 @@ func NewProvisioner(state state.State) *Provisioner {
 }
 
 type providerData struct {
-	UUID       string `yaml:"uuid"`
-	SecureBoot bool   `yaml:"secure_boot"`
+	UUID string `yaml:"uuid"`
+	// BootFactoryURL is the base URL of the image factory the machine's boot media is pretended
+	// to come from, empty to use the provider's configured factory. The machine identity
+	// (enterprise-ness, FIPS state) follows it until something is installed.
+	BootFactoryURL string `yaml:"boot_factory_url"`
+	SecureBoot     bool   `yaml:"secure_boot"`
 }
 
 // ProvisionSteps implements infra.Provisioner.
@@ -54,6 +59,14 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			err = pctx.UnmarshalProviderData(&pd)
 			if err != nil {
 				return fmt.Errorf("failed to unmarshal provider data: %w", err)
+			}
+
+			if pd.BootFactoryURL != "" {
+				var bootFactoryURL *url.URL
+
+				if bootFactoryURL, err = url.Parse(pd.BootFactoryURL); err != nil || bootFactoryURL.Scheme == "" || bootFactoryURL.Host == "" {
+					return fmt.Errorf("invalid provider data: boot_factory_url %q is not a valid base URL", pd.BootFactoryURL)
+				}
 			}
 
 			// the machine is already provisioned, so no need to do anything, just return the current machine state
@@ -100,6 +113,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				TalosVersion:   ms.TalosVersion,
 				ConnectionArgs: strings.Join(pctx.ConnectionParams.KernelArgs, " "),
 				SecureBoot:     pd.SecureBoot,
+				BootFactoryUrl: pd.BootFactoryURL,
 			}
 
 			pctx.SetMachineInfraID(fmt.Sprintf("%d", machineTask.TypedSpec().Value.Slot))

--- a/internal/pkg/schematic/schematic.go
+++ b/internal/pkg/schematic/schematic.go
@@ -24,9 +24,14 @@ type Service struct {
 	logger              *zap.Logger
 	cacheDir            string
 	imageFactoryBaseURL string
+	username            string
+	password            string
 }
 
-func NewService(cacheDir, imageFactoryBaseURL string, logger *zap.Logger) (*Service, error) {
+// NewService creates a schematic service. The credentials are optional and used as basic auth
+// against the image factory when set, as enterprise image factories require authentication for
+// schematic reads.
+func NewService(cacheDir, imageFactoryBaseURL, username, password string, logger *zap.Logger) (*Service, error) {
 	if cacheDir == "" {
 		userCacheDir, err := os.UserCacheDir()
 		if err != nil {
@@ -43,6 +48,8 @@ func NewService(cacheDir, imageFactoryBaseURL string, logger *zap.Logger) (*Serv
 	return &Service{
 		cacheDir:            cacheDir,
 		imageFactoryBaseURL: imageFactoryBaseURL,
+		username:            username,
+		password:            password,
 		logger:              logger,
 	}, nil
 }
@@ -96,7 +103,13 @@ func (svc *Service) getByID(ctx context.Context, id string) (*schematic.Schemati
 
 	// doesn't exist, get schematic
 
-	factoryClient, err := client.New(svc.imageFactoryBaseURL)
+	var clientOpts []client.Option
+
+	if svc.username != "" {
+		clientOpts = append(clientOpts, client.WithBasicAuth(svc.username, svc.password))
+	}
+
+	factoryClient, err := client.New(svc.imageFactoryBaseURL, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create factory client: %w", err)
 	}

--- a/internal/pkg/schematic/schematic_test.go
+++ b/internal/pkg/schematic/schematic_test.go
@@ -38,7 +38,7 @@ func TestGetByID(t *testing.T) {
 
 	logger.Info("test dir", zap.String("dir", cacheDir))
 
-	schematicService, err := schematicsvc.NewService(cacheDir, "https://factory.talos.dev", logger)
+	schematicService, err := schematicsvc.NewService(cacheDir, "https://factory.talos.dev", "", "", logger)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)


### PR DESCRIPTION
The emulated machines now derive their identity from their current Talos image, the way real machines do. An image coming from an enterprise image factory makes the machine report itself as a Talos Enterprise build with FIPS enabled, and the strict FIPS mode additionally follows the talos.fips140=strict kernel argument. The factory kind is detected from its Server response header, the same way Omni detects it.

The identity follows the image across installs and upgrades in all the supported flows, so switching between enterprise and regular images flips it in both directions. Before anything is installed, the identity comes from the boot media, which can be pointed at a different factory per machine request through the provider data.

Schematic reads can now authenticate against the image factory with optional credentials taken from the environment, as enterprise image factories require authentication.

Part of siderolabs/omni#2724.