### PR TITLE
refactor: simplify enterprise factory handling

### DIFF
--- a/cmd/talemu-infra-provider/main.go
+++ b/cmd/talemu-infra-provider/main.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -164,19 +162,9 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		factoryURL, err := url.Parse(imageFactoryBaseURL)
-		if err != nil {
-			return fmt.Errorf("invalid image factory URL %q: %w", imageFactoryBaseURL, err)
-		}
-
-		imageFactoryHost := factoryURL.Host
-		if imageFactoryHost == "" {
-			return fmt.Errorf("image factory URL %q has no host", imageFactoryBaseURL)
-		}
-
 		enterpriseChecker := factory.NewEnterpriseChecker()
 
-		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService, enterpriseChecker, imageFactoryBaseURL, cfg.nodeProxyingDisabled); err != nil {
+		if err = provider.RegisterControllers(runtime, kubernetes, nc, schematicService, enterpriseChecker, cfg.nodeProxyingDisabled); err != nil {
 			return err
 		}
 

--- a/cmd/talemu/main.go
+++ b/cmd/talemu/main.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -106,16 +105,6 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		factoryURL, err := url.Parse(cfg.imageFactoryBaseURL)
-		if err != nil {
-			return fmt.Errorf("invalid image factory URL %q: %w", cfg.imageFactoryBaseURL, err)
-		}
-
-		imageFactoryHost := factoryURL.Host
-		if imageFactoryHost == "" {
-			return fmt.Errorf("image factory URL %q has no host", cfg.imageFactoryBaseURL)
-		}
-
 		initialSchematicID, err := buildInitialSchematicID()
 		if err != nil {
 			return err
@@ -124,7 +113,7 @@ var rootCmd = &cobra.Command{
 		enterpriseChecker := factory.NewEnterpriseChecker()
 
 		for i := range cfg.machinesCount {
-			m, err := machine.NewMachine(fmt.Sprintf("%04d1802-c798-4da7-a410-f09abb48c8d8", i+1000), logger, emulatorState, schematicService, enterpriseChecker, cfg.imageFactoryBaseURL)
+			m, err := machine.NewMachine(fmt.Sprintf("%04d1802-c798-4da7-a410-f09abb48c8d8", i+1000), logger, emulatorState, schematicService, enterpriseChecker)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/machine/controllers/identity_test.go
+++ b/internal/pkg/machine/controllers/identity_test.go
@@ -130,6 +130,24 @@ func TestMachineIdentityFollowsImage(t *testing.T) {
 		a.Equal(runtime.FIPSStateDisabled, res.TypedSpec().FIPSState)
 		a.True(res.TypedSpec().SecureBoot, "secure boot is a firmware property and never follows the image")
 	})
+
+	// A same-version upgrade back to the enterprise factory flips the identity and restores FIPS.
+	// The existing strict kernel argument applies again once the running build supports FIPS.
+	_, err = safe.StateUpdateWithConflicts(ctx, st, bootImage.Metadata(), func(res *talos.Image) error {
+		res.TypedSpec().Value.Host = enterpriseFactoryHost
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	rtestutils.AssertResource(ctx, t, st, runtime.NewVersion().Metadata().ID(), func(res *runtime.Version, a *assert.Assertions) {
+		a.Equal("Talos Enterprise", res.TypedSpec().Name)
+		a.Equal("v1.14.0", res.TypedSpec().Version)
+	})
+	rtestutils.AssertResource(ctx, t, st, runtime.SecurityStateID, func(res *runtime.SecurityState, a *assert.Assertions) {
+		a.Equal(runtime.FIPSStateStrict, res.TypedSpec().FIPSState)
+		a.True(res.TypedSpec().SecureBoot)
+	})
 }
 
 // TestMachineIdentityCheckerFailure verifies that a broken image factory probe neither blocks the

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -58,24 +58,20 @@ type Machine struct {
 	shutdown          chan struct{}
 	schematicService  *schematic.Service
 	enterpriseChecker controllers.EnterpriseChecker
-
-	// imageFactoryBaseURL is the base URL of the configured image factory, scheme included.
-	imageFactoryBaseURL string
-	uuid                string
+	uuid              string
 }
 
 // NewMachine creates a Machine.
 func NewMachine(uuid string, logger *zap.Logger, globalState state.State, schematicService *schematic.Service,
-	enterpriseChecker controllers.EnterpriseChecker, imageFactoryBaseURL string,
+	enterpriseChecker controllers.EnterpriseChecker,
 ) (*Machine, error) {
 	return &Machine{
-		uuid:                uuid,
-		logger:              logger,
-		globalState:         globalState,
-		schematicService:    schematicService,
-		enterpriseChecker:   enterpriseChecker,
-		imageFactoryBaseURL: imageFactoryBaseURL,
-		shutdown:            make(chan struct{}, 1),
+		uuid:              uuid,
+		logger:            logger,
+		globalState:       globalState,
+		schematicService:  schematicService,
+		enterpriseChecker: enterpriseChecker,
+		shutdown:          make(chan struct{}, 1),
 	}, nil
 }
 
@@ -116,21 +112,16 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 	m.logger = zap.New(core).With(zap.String("machine", machineID), zap.String("uuid", m.uuid))
 
-	imageFactoryHost, err := hostOfURL(m.imageFactoryBaseURL)
-	if err != nil {
-		return err
-	}
-
 	// the configured base URL is used as-is, so a plain-HTTP factory keeps working
 	bootFactoryURL := opts.bootFactoryURL
 	if bootFactoryURL == "" {
-		bootFactoryURL = m.imageFactoryBaseURL
+		bootFactoryURL = m.schematicService.ImageFactoryBaseURL()
 	}
 
 	rt, err := truntime.NewRuntime(
 		ctx, m.logger, slot, machineID, m.globalState,
 		kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService,
-		m.enterpriseChecker, imageFactoryHost, bootFactoryURL, opts.nodeProxyingDisabled,
+		m.enterpriseChecker, m.schematicService.ImageFactoryHost(), bootFactoryURL, opts.nodeProxyingDisabled,
 	)
 	if err != nil {
 		return fmt.Errorf("COSI runtime creation failed: %w", err)

--- a/internal/pkg/machine/services/lifecycle_test.go
+++ b/internal/pkg/machine/services/lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
 	"github.com/siderolabs/talemu/internal/pkg/machine/services"
 )
 
@@ -145,7 +146,7 @@ func TestLifecycleUpgrade(t *testing.T) {
 
 	srv := &recordingStream[*machine.LifecycleServiceUpgradeResponse]{ctx: t.Context()}
 	err := svc.Upgrade(&machine.LifecycleServiceUpgradeRequest{
-		Source: &machine.InstallArtifactsSource{ImageName: "factory.talos.dev/installer/abc123:v1.14.1"},
+		Source: &machine.InstallArtifactsSource{ImageName: "factory-enterprise.staging.talos.dev/installer/abc123:v1.14.0"},
 	}, srv)
 	require.NoError(t, err)
 
@@ -153,6 +154,11 @@ func TestLifecycleUpgrade(t *testing.T) {
 	require.NotEmpty(t, srv.sent)
 	require.NotEmpty(t, srv.sent[0].GetProgress().GetMessage())
 	require.Equal(t, int32(0), srv.sent[len(srv.sent)-1].GetProgress().GetExitCode())
+
+	image, err := safe.ReaderGetByID[*talos.Image](t.Context(), st, talos.ImageID)
+	require.NoError(t, err)
+	require.Equal(t, "factory-enterprise.staging.talos.dev", image.TypedSpec().Value.Host)
+	require.Equal(t, "v1.14.0", image.TypedSpec().Value.Version)
 }
 
 func TestLifecycleConcurrentOperationRejected(t *testing.T) {

--- a/internal/pkg/provider/controllers/machine/machine.go
+++ b/internal/pkg/provider/controllers/machine/machine.go
@@ -31,7 +31,6 @@ type TaskSpec struct {
 	Params               *machine.SideroLinkParams
 	Kubernetes           *kubefactory.Kubernetes
 	NC                   *network.Client
-	ImageFactoryBaseURL  string
 	NodeProxyingDisabled bool
 }
 
@@ -47,7 +46,7 @@ func (s TaskSpec) Equal(other TaskSpec) bool {
 
 // RunTask implements task.TaskSpec.
 func (s TaskSpec) RunTask(ctx context.Context, logger *zap.Logger, _ any) error {
-	m, err := machine.NewMachine(s.Machine.TypedSpec().Value.Uuid, logger, s.GlobalState, s.SchematicService, s.EnterpriseChecker, s.ImageFactoryBaseURL)
+	m, err := machine.NewMachine(s.Machine.TypedSpec().Value.Uuid, logger, s.GlobalState, s.SchematicService, s.EnterpriseChecker)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/provider/controllers/machine_runner.go
+++ b/internal/pkg/provider/controllers/machine_runner.go
@@ -36,7 +36,6 @@ type MachineController struct {
 	globalState          state.State
 	schematicService     *schematic.Service
 	enterpriseChecker    controllers.EnterpriseChecker
-	imageFactoryBaseURL  string
 	nodeProxyingDisabled bool
 }
 
@@ -44,7 +43,7 @@ type MachineController struct {
 func NewMachineController(
 	globalState state.State, kubernetes *kubefactory.Kubernetes, nc *network.Client,
 	schematicService *schematic.Service, enterpriseChecker controllers.EnterpriseChecker,
-	imageFactoryBaseURL string, nodeProxyingDisabled bool,
+	nodeProxyingDisabled bool,
 ) *MachineController {
 	return &MachineController{
 		runner:               task.NewEqualRunner[machinetask.TaskSpec](),
@@ -53,7 +52,6 @@ func NewMachineController(
 		nc:                   nc,
 		schematicService:     schematicService,
 		enterpriseChecker:    enterpriseChecker,
-		imageFactoryBaseURL:  imageFactoryBaseURL,
 		nodeProxyingDisabled: nodeProxyingDisabled,
 	}
 }
@@ -128,7 +126,6 @@ func (ctrl *MachineController) Run(ctx context.Context, r controller.Runtime, lo
 				GlobalState:          ctrl.globalState,
 				SchematicService:     ctrl.schematicService,
 				EnterpriseChecker:    ctrl.enterpriseChecker,
-				ImageFactoryBaseURL:  ctrl.imageFactoryBaseURL,
 				Kubernetes:           ctrl.kubernetes,
 				Params:               params,
 				NC:                   ctrl.nc,

--- a/internal/pkg/provider/provider.go
+++ b/internal/pkg/provider/provider.go
@@ -19,10 +19,10 @@ import (
 // RegisterControllers registers additional controllers required for the infra provider.
 func RegisterControllers(
 	runtime *emu.Runtime, kubernetes *kubefactory.Kubernetes, nc *network.Client, schematicService *schematic.Service,
-	enterpriseChecker machinecontrollers.EnterpriseChecker, imageFactoryBaseURL string, nodeProxyingDisabled bool,
+	enterpriseChecker machinecontrollers.EnterpriseChecker, nodeProxyingDisabled bool,
 ) error {
 	controllers := []controller.Controller{
-		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService, enterpriseChecker, imageFactoryBaseURL, nodeProxyingDisabled),
+		controllers.NewMachineController(runtime.State(), kubernetes, nc, schematicService, enterpriseChecker, nodeProxyingDisabled),
 	}
 
 	for _, ctrl := range controllers {

--- a/internal/pkg/schematic/schematic.go
+++ b/internal/pkg/schematic/schematic.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -20,18 +21,37 @@ import (
 )
 
 type Service struct {
-	sf                  singleflight.Group
-	logger              *zap.Logger
-	cacheDir            string
-	imageFactoryBaseURL string
-	username            string
-	password            string
+	sf               singleflight.Group
+	logger           *zap.Logger
+	cacheDir         string
+	factoryClient    *client.Client
+	imageFactoryHost string
 }
 
 // NewService creates a schematic service. The credentials are optional and used as basic auth
 // against the image factory when set, as enterprise image factories require authentication for
 // schematic reads.
 func NewService(cacheDir, imageFactoryBaseURL, username, password string, logger *zap.Logger) (*Service, error) {
+	factoryURL, err := url.Parse(imageFactoryBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid image factory URL %q: %w", imageFactoryBaseURL, err)
+	}
+
+	if factoryURL.Scheme == "" || factoryURL.Host == "" {
+		return nil, fmt.Errorf("invalid image factory URL %q: scheme and host are required", imageFactoryBaseURL)
+	}
+
+	var clientOpts []client.Option
+
+	if username != "" {
+		clientOpts = append(clientOpts, client.WithBasicAuth(username, password))
+	}
+
+	factoryClient, err := client.New(imageFactoryBaseURL, clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create factory client: %w", err)
+	}
+
 	if cacheDir == "" {
 		userCacheDir, err := os.UserCacheDir()
 		if err != nil {
@@ -46,12 +66,21 @@ func NewService(cacheDir, imageFactoryBaseURL, username, password string, logger
 	}
 
 	return &Service{
-		cacheDir:            cacheDir,
-		imageFactoryBaseURL: imageFactoryBaseURL,
-		username:            username,
-		password:            password,
-		logger:              logger,
+		cacheDir:         cacheDir,
+		factoryClient:    factoryClient,
+		imageFactoryHost: factoryURL.Host,
+		logger:           logger,
 	}, nil
+}
+
+// ImageFactoryBaseURL returns the base URL of the configured image factory client.
+func (svc *Service) ImageFactoryBaseURL() string {
+	return svc.factoryClient.BaseURL()
+}
+
+// ImageFactoryHost returns the configured image factory host.
+func (svc *Service) ImageFactoryHost() string {
+	return svc.imageFactoryHost
 }
 
 func (svc *Service) GetByID(ctx context.Context, id string) (*schematic.Schematic, error) {
@@ -103,21 +132,10 @@ func (svc *Service) getByID(ctx context.Context, id string) (*schematic.Schemati
 
 	// doesn't exist, get schematic
 
-	var clientOpts []client.Option
-
-	if svc.username != "" {
-		clientOpts = append(clientOpts, client.WithBasicAuth(svc.username, svc.password))
-	}
-
-	factoryClient, err := client.New(svc.imageFactoryBaseURL, clientOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create factory client: %w", err)
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	schematic, err := factoryClient.SchematicGet(ctx, id)
+	schematic, err := svc.factoryClient.SchematicGet(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schematic from factory: %w", err)
 	}

--- a/internal/pkg/schematic/schematic_test.go
+++ b/internal/pkg/schematic/schematic_test.go
@@ -30,6 +30,18 @@ const (
             - siderolabs/qemu-guest-agent`
 )
 
+func TestNewService(t *testing.T) {
+	t.Parallel()
+
+	service, err := schematicsvc.NewService(t.TempDir(), "http://factory.local:8080/base", "user", "password", nil)
+	require.NoError(t, err)
+	require.Equal(t, "http://factory.local:8080/base", service.ImageFactoryBaseURL())
+	require.Equal(t, "factory.local:8080", service.ImageFactoryHost())
+
+	_, err = schematicsvc.NewService(t.TempDir(), "factory.local", "", "", nil)
+	require.Error(t, err)
+}
+
 func TestGetByID(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
This continues #70 with the final simplification and switch coverage that was omitted from the merged commit. Image factory configuration is validated once and reused across machine startup.
