### PR TITLE
fix: resolve emulated machines' schematics instead of inventing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,31 @@ To be used in pair with Omni.
 
 ## Running Emulator Static Mode
 
-Do `Copy Kernel Args` in the Omni UI.
+Static mode emulates machines that join Omni by themselves, as if they had booted some boot media.
+So tell it which media they booted.
 
-Create `hack/compose/docker-compose.override.yml` and paste copied kernel args there.
+### From a factory schematic (the normal case)
 
-Final YAML file can look like this:
+Talos boot media is built by an image factory, and its schematic is the media's identity: it carries both the extra kernel args the machine boots with, including how to reach Omni, and the extensions the machine has.
+Download an image for your Omni instance and pass the schematic ID of it:
+
+```yaml
+version: '3.8'
+services:
+  talemu:
+    command: >-
+      args:
+        - --schematic-id=e2e8b4d5c0a...
+        - --machines=100
+```
+
+The schematic is read from the image factory at startup, and startup fails if it does not hold that schematic, since machines booted from media nobody has would never come up either.
+Use `--image-factory-base-url` for a factory other than the public one.
+
+### Without a factory
+
+Media built locally, with `imager` rather than a factory, has no schematic.
+Give the kernel args and the extensions directly instead:
 
 ```yaml
 version: '3.8'
@@ -18,8 +38,16 @@ services:
     command: >-
       args:
         - --kernel-args="siderolink.api=grpc://192.168.88.219:8090?jointoken=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD talos.events.sink=[fdae:41e4:649b:9303::1]:8090 talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092"
+        - --extensions=siderolabs/hello-world-service
         - --machines=100
 ```
+
+Those machines report no schematic, exactly as a locally built image does.
+`Copy Kernel Args` in the Omni UI gives a usable value for `--kernel-args`.
+
+`--schematic-id` and `--kernel-args` are mutually exclusive, and so are
+`--schematic-id` and `--extensions`, because a schematic already carries both.
+Neither is required: SideroLink is optional in Talos, and machines given no boot media info at all simply run standalone and join nothing.
 
 Run `make docker-compose-up` command.
 

--- a/cmd/talemu/main.go
+++ b/cmd/talemu/main.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/siderolabs/image-factory/pkg/schematic"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/spf13/cobra"
 	"go.uber.org/multierr"
@@ -44,9 +43,16 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("--extra-disks must be between 0 and %d, got %d", machine.MaxExtraDisks, cfg.extraDisks)
 		}
 
-		params, err := machine.ParseKernelArgs(cfg.kernelArgs)
-		if err != nil {
-			return err
+		// A schematic describes the whole boot media, kernel args included, so taking
+		// both would mean deciding which one wins. Neither is required: SideroLink is
+		// optional in Talos, and machines given no boot media info at all simply run
+		// standalone and join nothing.
+		if cfg.schematicID != "" && cmd.Flags().Changed("kernel-args") {
+			return errors.New("--schematic-id and --kernel-args are mutually exclusive: a schematic already carries the kernel args of the media it describes")
+		}
+
+		if cfg.schematicID != "" && cmd.Flags().Changed("extensions") {
+			return errors.New("--schematic-id and --extensions are mutually exclusive: a schematic already lists the extensions of the media it describes")
 		}
 
 		eg, ctx := errgroup.WithContext(cmd.Context())
@@ -109,9 +115,39 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		initialSchematicID, err := buildInitialSchematicID()
+		// Resolve the boot media the machines are pretending to have booted from.
+		//
+		// With a schematic ID, that media came from an image factory, so the factory
+		// is asked for it up front: it is the source of truth for the kernel args and
+		// the extensions, and a missing one is a mistake worth failing on now rather
+		// than leaving every machine to rediscover it forever.
+		//
+		// Real Talos would not need the round trip, since it runs the media and knows
+		// its own kernel args and extensions. The emulator does not run it, so
+		// fetching the schematic is how it recovers the same facts.
+		kernelArgs := cfg.kernelArgs
+
+		if cfg.schematicID != "" {
+			sch, schErr := schematicService.GetByID(ctx, cfg.schematicID, "")
+			if schErr != nil {
+				return fmt.Errorf("schematic %q could not be read from %s: %w",
+					cfg.schematicID, schematicService.ImageFactoryBaseURL(), schErr)
+			}
+
+			kernelArgs = strings.Join(sch.Customization.ExtraKernelArgs, " ")
+		}
+
+		params, err := machine.ParseKernelArgs(kernelArgs)
 		if err != nil {
 			return err
+		}
+
+		// With a schematic the args above came out of it, and the machines read the
+		// command line from the schematic too, so passing them on as well would report
+		// every argument twice. Only the caller knows this, which is why the shared
+		// machine code does not try to work it out.
+		if cfg.schematicID != "" {
+			params.RawKernelArgs = ""
 		}
 
 		enterpriseChecker := factory.NewEnterpriseChecker()
@@ -123,8 +159,12 @@ var rootCmd = &cobra.Command{
 			}
 
 			eg.Go(func() error {
-				return m.Run(ctx, params, i+1000, kubernetes, machine.WithNetworkClient(nc), machine.WithTalosVersion(cfg.talosVersion),
-					machine.WithSchematic(initialSchematicID), machine.WithNodeProxyingDisabled(cfg.nodeProxyingDisabled),
+				return m.Run(ctx, params, i+1000, kubernetes,
+					machine.WithNetworkClient(nc),
+					machine.WithTalosVersion(cfg.talosVersion),
+					machine.WithSchematic(cfg.schematicID),
+					machine.WithExtensions(cfg.extensions),
+					machine.WithNodeProxyingDisabled(cfg.nodeProxyingDisabled),
 					machine.WithExtraDisks(cfg.extraDisks))
 			})
 
@@ -175,21 +215,9 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func buildInitialSchematicID() (string, error) {
-	initialSchematic := schematic.Schematic{
-		Customization: schematic.Customization{
-			ExtraKernelArgs: strings.Fields(cfg.kernelArgs),
-			SystemExtensions: schematic.SystemExtensions{
-				OfficialExtensions: cfg.extensions,
-			},
-		},
-	}
-
-	return initialSchematic.ID()
-}
-
 var cfg struct {
 	kernelArgs           string
+	schematicID          string
 	talosVersion         string
 	schematicCacheDir    string
 	imageFactoryBaseURL  string
@@ -213,14 +241,18 @@ func app() error {
 }
 
 func init() {
-	rootCmd.Flags().StringSliceVar(&cfg.extensions, "extensions", []string{emuconst.OfficialExtensionPrefix + "hello-world-service"}, "list of extensions to enable")
-	rootCmd.Flags().StringVar(&cfg.kernelArgs, "kernel-args", "", "specify the whole configuration using kernel args string")
+	rootCmd.Flags().StringSliceVar(&cfg.extensions, "extensions", []string{emuconst.OfficialExtensionPrefix + "hello-world-service"},
+		"list of extensions to report, for media not built by an image factory (mutually exclusive with --schematic-id)")
+	rootCmd.Flags().StringVar(&cfg.kernelArgs, "kernel-args", "",
+		"specify the whole configuration using kernel args string, for media not built by an image factory (mutually exclusive with --schematic-id)")
+	rootCmd.Flags().StringVar(&cfg.schematicID, "schematic-id", "",
+		"schematic ID of the boot media the machines pretend to have booted from; it must exist in the image factory, which supplies the kernel args and extensions")
 	rootCmd.Flags().StringVar(&cfg.talosVersion, "talos-version", constants.DefaultTalosVersion, "specify the Talos version to use")
 	rootCmd.Flags().StringVar(&cfg.schematicCacheDir, "schematic-cache-dir", "/tmp/talemu-schematics", "the directory to use for caching schematics")
 	rootCmd.Flags().StringVar(&cfg.imageFactoryBaseURL, "image-factory-base-url", emuconst.DefaultImageFactoryBaseURL, "base URL of the image factory")
 	rootCmd.Flags().IntVar(&cfg.machinesCount, "machines", 1, "the number of machines to emulate")
 	rootCmd.Flags().IntVar(&cfg.extraDisks, "extra-disks", 0,
-		fmt.Sprintf("the number of additional empty disks to give each machine, named vdb onwards (max %d)", machine.MaxExtraDisks))
+		fmt.Sprintf("the number of additional empty disks to give each machine, between 0 and %d", machine.MaxExtraDisks))
 	rootCmd.Flags().BoolVar(&cfg.nodeProxyingDisabled, "disable-node-proxying", false,
 		"disable node-to-node proxying in apid: rejects the 'node' header, validates that a single-entry 'nodes' header targets this node, multi-node 'nodes' is still proxied")
 }

--- a/internal/pkg/machine/controllers/extension_status.go
+++ b/internal/pkg/machine/controllers/extension_status.go
@@ -27,6 +27,17 @@ import (
 type ExtensionStatusController struct {
 	SchematicService *schematic.Service
 	ImageFactoryHost string
+
+	// BootFactoryURL is the factory the machine booted from. It is the fallback for
+	// resolving which factory holds the current schematic, and stops applying once an
+	// install or an upgrade replaces the image.
+	BootFactoryURL string
+
+	// LocalExtensions is reported when the machine has no schematic, which is the
+	// case for boot media that was not built by an image factory. Real Talos reads
+	// its extensions from local metadata rather than from a factory, so a machine
+	// without a schematic still knows what it has.
+	LocalExtensions []string
 }
 
 // Name implements controller.Controller interface.
@@ -73,45 +84,52 @@ func (ctrl *ExtensionStatusController) Run(ctx context.Context, r controller.Run
 		case <-r.EventCh():
 		}
 
-		schematicID, err := readCurrentSchematicID(ctx, r, ctrl.ImageFactoryHost)
+		schematicID, factoryURL, err := readCurrentSchematic(ctx, r, ctrl.ImageFactoryHost, ctrl.BootFactoryURL)
 		if err != nil {
 			return fmt.Errorf("failed to read current schematic ID: %w", err)
 		}
 
-		if schematicID == "" {
-			continue
-		}
-
-		sch, err := ctrl.SchematicService.GetByID(ctx, schematicID)
-		if err != nil {
-			return fmt.Errorf("failed to get schematic by ID %q: %w", schematicID, err)
-		}
-
 		touched := map[string]any{}
+		extensionList := ctrl.LocalExtensions
 
-		extensionStatus := runtime.NewExtensionStatus(runtime.NamespaceName, constants.SchematicIDExtensionName)
+		// With no schematic the machine reports the extensions it knows about locally
+		// and no schematic ID extension, exactly like a Talos image that an image
+		// factory did not build. Otherwise the schematic is the source of truth, and
+		// the schematic ID is published as an extension the way a factory image does.
+		if schematicID != "" {
+			sch, schErr := ctrl.SchematicService.GetByID(ctx, schematicID, factoryURL)
+			if schErr != nil {
+				return fmt.Errorf("failed to get schematic by ID %q: %w", schematicID, schErr)
+			}
 
-		data, err := sch.Marshal()
-		if err != nil {
-			return err
+			extensionList = sch.Customization.SystemExtensions.OfficialExtensions
+
+			extensionStatus := runtime.NewExtensionStatus(runtime.NamespaceName, constants.SchematicIDExtensionName)
+
+			var data []byte
+
+			data, err = sch.Marshal()
+			if err != nil {
+				return err
+			}
+
+			if err = safe.WriterModify(ctx, r, extensionStatus, func(res *runtime.ExtensionStatus) error {
+				res.TypedSpec().Metadata.Name = constants.SchematicIDExtensionName
+				res.TypedSpec().Metadata.Version = schematicID
+				res.TypedSpec().Metadata.ExtraInfo = string(data)
+
+				touched[res.Metadata().ID()] = struct{}{}
+
+				return nil
+			}); err != nil {
+				return err
+			}
 		}
 
-		if err = safe.WriterModify(ctx, r, extensionStatus, func(res *runtime.ExtensionStatus) error {
-			res.TypedSpec().Metadata.Name = constants.SchematicIDExtensionName
-			res.TypedSpec().Metadata.Version = schematicID
-			res.TypedSpec().Metadata.ExtraInfo = string(data)
-
-			touched[res.Metadata().ID()] = struct{}{}
-
-			return nil
-		}); err != nil {
-			return err
-		}
-
-		for _, extension := range sch.Customization.SystemExtensions.OfficialExtensions {
+		for _, extension := range extensionList {
 			nameWithoutPrefix := strings.TrimPrefix(extension, emuconst.OfficialExtensionPrefix)
 
-			extensionStatus = runtime.NewExtensionStatus(runtime.NamespaceName, nameWithoutPrefix)
+			extensionStatus := runtime.NewExtensionStatus(runtime.NamespaceName, nameWithoutPrefix)
 
 			touched[extensionStatus.Metadata().ID()] = struct{}{}
 

--- a/internal/pkg/machine/controllers/kernel_cmdline.go
+++ b/internal/pkg/machine/controllers/kernel_cmdline.go
@@ -27,6 +27,11 @@ type KernelCmdlineController struct {
 	SchematicService *schematicsvc.Service
 	ImageFactoryHost string
 	BaseKernelArgs   string
+
+	// BootFactoryURL is the factory the machine booted from. It is the fallback for
+	// resolving which factory holds the current schematic, and stops applying once an
+	// install or an upgrade replaces the image.
+	BootFactoryURL string
 }
 
 // Name implements controller.Controller interface.
@@ -71,7 +76,7 @@ func (ctrl *KernelCmdlineController) Run(ctx context.Context, r controller.Runti
 		case <-r.EventCh():
 		}
 
-		schematicID, err := readCurrentSchematicID(ctx, r, ctrl.ImageFactoryHost)
+		schematicID, factoryURL, err := readCurrentSchematic(ctx, r, ctrl.ImageFactoryHost, ctrl.BootFactoryURL)
 		if err != nil {
 			return fmt.Errorf("failed to read current schematic ID: %w", err)
 		}
@@ -81,14 +86,19 @@ func (ctrl *KernelCmdlineController) Run(ctx context.Context, r controller.Runti
 		if schematicID != "" {
 			var sch *schematic.Schematic
 
-			if sch, err = ctrl.SchematicService.GetByID(ctx, schematicID); err != nil {
+			if sch, err = ctrl.SchematicService.GetByID(ctx, schematicID, factoryURL); err != nil {
 				return fmt.Errorf("failed to get schematic by ID %q: %w", schematicID, err)
 			}
 
 			extraKernelArgs = sch.Customization.ExtraKernelArgs
 		}
 
-		cmdline := ctrl.BaseKernelArgs + " " + strings.Join(slices.Concat(extraKernelArgs, []string{"talemu=1"}), " ")
+		// The base args are empty when a schematic describes the boot media, since the
+		// schematic then supplies the whole command line, so build this by joining
+		// only the parts that exist rather than concatenating blindly.
+		parts := slices.Concat(strings.Fields(ctrl.BaseKernelArgs), extraKernelArgs, []string{"talemu=1"})
+
+		cmdline := strings.Join(parts, " ")
 		logger.Info("set cmdline", zap.String("cmdline", cmdline), zap.Strings("extra_args", extraKernelArgs))
 
 		if err = safe.WriterModify(ctx, r, runtime.NewKernelCmdline(), func(res *runtime.KernelCmdline) error {

--- a/internal/pkg/machine/controllers/schematic.go
+++ b/internal/pkg/machine/controllers/schematic.go
@@ -16,34 +16,45 @@ import (
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
 )
 
-func readCurrentSchematicID(ctx context.Context, r controller.Runtime, imageFactoryHost string) (string, error) {
+// readCurrentSchematic returns the schematic of the machine's current Talos image
+// together with the base URL of the factory that holds it.
+//
+// The two travel together on purpose. A schematic only exists in the factory that
+// built it, and installing or upgrading replaces both the schematic and the
+// factory it came from, so resolving the current schematic against the factory the
+// machine originally booted from would ask the wrong one. The precedence over
+// installed image, config install image and boot media is shared with
+// resolveImageSourceURL.
+func readCurrentSchematic(ctx context.Context, r controller.Runtime, imageFactoryHost, bootFactoryURL string) (schematicID, factoryURL string, err error) {
 	schematicContent, err := machineconfig.GetComplete(ctx, r)
 	if err != nil && !state.IsNotFoundError(err) {
-		return "", err
+		return "", "", err
 	}
 
 	image, err := safe.ReaderGetByID[*talos.Image](ctx, r, talos.ImageID)
 	if err != nil && !state.IsNotFoundError(err) {
-		return "", err
+		return "", "", err
 	}
 
 	if image == nil && schematicContent == nil {
-		return "", nil
+		return "", "", nil
 	}
 
+	factoryURL = resolveImageSourceURL(image, schematicContent, imageFactoryHost, bootFactoryURL)
+
 	if image != nil {
-		return image.TypedSpec().Value.Schematic, nil
+		return image.TypedSpec().Value.Schematic, factoryURL, nil
 	}
 
 	installImage := schematicContent.Container().RawV1Alpha1().Machine().Install().Image()
 	if installImage == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	parsed, err := talos.ParseImageRef(imageFactoryHost, installImage)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse schematic id from the install image: %w", err)
+		return "", "", fmt.Errorf("failed to parse schematic id from the install image: %w", err)
 	}
 
-	return parsed.Schematic, nil
+	return parsed.Schematic, factoryURL, nil
 }

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -86,6 +86,32 @@ func extraDisks(count int) []resource.Resource {
 	return resources
 }
 
+// seedBootMedia records the boot media of a machine that has not installed yet.
+//
+// State survives restarts, so a machine started again with different media would
+// otherwise keep reporting the old one forever. Until an install happens, Talos is
+// running from ISO or PXE with nothing on disk, and booting such a machine from
+// other media genuinely does change what it is running, so the seeded values take
+// precedence. After an install the disk decides, and the installed image is left
+// alone.
+func seedBootMedia(ctx context.Context, st state.State, image *talos.Image) error {
+	_, err := safe.StateGetByID[*block.SystemDisk](ctx, st, block.SystemDiskID)
+
+	switch {
+	case err == nil:
+		// installed: the disk holds what the machine runs, not the boot media
+		return nil
+	case !state.IsNotFoundError(err):
+		return fmt.Errorf("failed to read system disk: %w", err)
+	}
+
+	return st.Modify(ctx, talos.NewImage(talos.NamespaceName, talos.ImageID), func(res resource.Resource) error {
+		res.(*talos.Image).TypedSpec().Value = image.TypedSpec().Value //nolint:forcetypeassert,errcheck
+
+		return nil
+	})
+}
+
 // Machine is a single Talos machine.
 type Machine struct {
 	globalState       state.State
@@ -154,10 +180,15 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 		bootFactoryURL = m.schematicService.ImageFactoryBaseURL()
 	}
 
+	// The raw args are whatever the caller knows that the schematic does not carry.
+	// The provider passes connection args here because it conveys them separately from
+	// the boot media, while static mode reads everything from the schematic and passes
+	// nothing, so the two never double-count.
 	rt, err := truntime.NewRuntime(
 		ctx, m.logger, slot, machineID, m.globalState,
 		kubernetes, opts.nc, logSink, siderolinkParams.RawKernelArgs, m.schematicService,
 		m.enterpriseChecker, m.schematicService.ImageFactoryHost(), bootFactoryURL, opts.nodeProxyingDisabled,
+		opts.extensions,
 	)
 	if err != nil {
 		return fmt.Errorf("COSI runtime creation failed: %w", err)
@@ -173,12 +204,20 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	hardwareInformation.TypedSpec().ProductName = "Talos Emulator"
 	hardwareInformation.TypedSpec().Manufacturer = "qemu"
 
-	siderolinkConfig := siderolink.NewConfig(config.NamespaceName, siderolink.ConfigID)
-	siderolinkConfig.TypedSpec().APIEndpoint = siderolinkParams.APIEndpoint
-	siderolinkConfig.TypedSpec().JoinToken = siderolinkParams.JoinToken
-	siderolinkConfig.TypedSpec().Host = siderolinkParams.Host
-	siderolinkConfig.TypedSpec().Insecure = siderolinkParams.Insecure
-	siderolinkConfig.TypedSpec().Tunnel = siderolinkParams.TunnelMode
+	// SideroLink is optional: bare Talos does not join anything, and boot media
+	// without SideroLink kernel args emulates exactly that. Only seed the config
+	// when there is an endpoint to join, the connection controller treats a
+	// missing config as "nothing to do" and the machine simply runs standalone.
+	if siderolinkParams.APIEndpoint != "" {
+		siderolinkConfig := siderolink.NewConfig(config.NamespaceName, siderolink.ConfigID)
+		siderolinkConfig.TypedSpec().APIEndpoint = siderolinkParams.APIEndpoint
+		siderolinkConfig.TypedSpec().JoinToken = siderolinkParams.JoinToken
+		siderolinkConfig.TypedSpec().Host = siderolinkParams.Host
+		siderolinkConfig.TypedSpec().Insecure = siderolinkParams.Insecure
+		siderolinkConfig.TypedSpec().Tunnel = siderolinkParams.TunnelMode
+
+		resources = append(resources, siderolinkConfig)
+	}
 
 	platformMetadata := runtime.NewPlatformMetadataSpec(runtime.NamespaceName, runtime.PlatformMetadataID)
 	platformMetadata.TypedSpec().Platform = "metal"
@@ -262,7 +301,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	resources = append(
 		resources,
 		hardwareInformation,
-		siderolinkConfig,
 		platformMetadata,
 		processorInfo,
 		securityState,
@@ -280,6 +318,8 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	// can target any disk, at which point the layout moves there.
 	resources = append(resources, blocklayout.Build(diskDevName)...)
 	resources = append(resources, extraDisks(opts.extraDisks)...)
+
+	var bootMedia *talos.Image
 
 	if opts.schematic != "" || opts.talosVersion != "" {
 		image := talos.NewImage(talos.NamespaceName, talos.ImageID)
@@ -299,7 +339,7 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 
 		image.TypedSpec().Value.Host = bootFactoryHost
 
-		resources = append(resources, image)
+		bootMedia = image
 	}
 
 	for _, r := range resources {
@@ -309,6 +349,12 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 			}
 
 			return fmt.Errorf("failed to create resource %s: %w", r.Metadata(), err)
+		}
+	}
+
+	if bootMedia != nil {
+		if err = seedBootMedia(ctx, rt.State(), bootMedia); err != nil {
+			return err
 		}
 	}
 

--- a/internal/pkg/machine/options.go
+++ b/internal/pkg/machine/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	talosVersion         string
 	schematic            string
 	bootFactoryURL       string
+	extensions           []string
 	extraDisks           int
 	secureBoot           bool
 	nodeProxyingDisabled bool
@@ -81,5 +82,17 @@ func WithBootFactoryURL(value string) Option {
 func WithExtraDisks(count int) Option {
 	return func(o *Options) {
 		o.extraDisks = count
+	}
+}
+
+// WithExtensions sets the extensions the machine reports when it has no schematic.
+//
+// A machine built by an image factory carries a schematic that lists its
+// extensions, and that takes precedence. Media built without a factory has no
+// schematic, so the extensions have to be stated directly, the same way real
+// Talos reads them from local metadata instead of asking a factory.
+func WithExtensions(extensions []string) Option {
+	return func(o *Options) {
+		o.extensions = extensions
 	}
 }

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -44,6 +44,7 @@ type Runtime struct {
 func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, globalState state.State,
 	kubernetes *kubefactory.Kubernetes, nc *network.Client, logSink *logging.ZapCore, baseKernelArgs string, schematicService *schematic.Service,
 	enterpriseChecker controllers.EnterpriseChecker, imageFactoryHost, bootFactoryURL string, nodeProxyingDisabled bool,
+	localExtensions []string,
 ) (*Runtime, error) {
 	stateDir := GetStateDir(id)
 
@@ -109,12 +110,15 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 		controllers.NewRootOSController(),
 		&controllers.ExtensionStatusController{
 			SchematicService: schematicService,
+			LocalExtensions:  localExtensions,
 			ImageFactoryHost: imageFactoryHost,
+			BootFactoryURL:   bootFactoryURL,
 		},
 		&controllers.KernelCmdlineController{
 			BaseKernelArgs:   baseKernelArgs,
 			SchematicService: schematicService,
 			ImageFactoryHost: imageFactoryHost,
+			BootFactoryURL:   bootFactoryURL,
 		},
 		&controllers.MachineStatusController{State: st, ImageFactoryHost: imageFactoryHost},
 		&controllers.VersionController{

--- a/internal/pkg/schematic/schematic.go
+++ b/internal/pkg/schematic/schematic.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/siderolabs/image-factory/pkg/client"
@@ -21,10 +22,11 @@ import (
 )
 
 type Service struct {
-	sf               singleflight.Group
-	logger           *zap.Logger
+	sf            singleflight.Group
+	logger        *zap.Logger
+	factoryClient *client.Client
+
 	cacheDir         string
-	factoryClient    *client.Client
 	imageFactoryHost string
 }
 
@@ -83,9 +85,63 @@ func (svc *Service) ImageFactoryHost() string {
 	return svc.imageFactoryHost
 }
 
-func (svc *Service) GetByID(ctx context.Context, id string) (*schematic.Schematic, error) {
-	ch := svc.sf.DoChan(id, func() (any, error) {
-		return svc.getByID(ctx, id)
+// normalizeFactoryURL puts a factory base URL in a comparable form, so that two
+// spellings of the same factory are recognized as one.
+//
+// The two URLs being compared reach the emulator from different places, the
+// command line of this process and the provider data of a machine, so a trailing
+// slash or a differently cased host is likely. Treating those as different
+// factories would silently drop the credentials belonging to the configured one.
+func normalizeFactoryURL(baseURL string) string {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+
+	return parsed.String()
+}
+
+// clientFor returns the factory client for a base URL, falling back to the
+// configured factory when the URL is empty or is that same factory.
+//
+// Credentials belong to the configured factory and are only ever sent there. A
+// different factory gets an unauthenticated client, since there is no reason to
+// believe one factory's credentials are valid at another, and every reason not to
+// send them somewhere they were not issued for.
+func (svc *Service) clientFor(baseURL string) (*client.Client, error) {
+	normalized := normalizeFactoryURL(baseURL)
+
+	if normalized == "" || normalized == normalizeFactoryURL(svc.factoryClient.BaseURL()) {
+		return svc.factoryClient, nil
+	}
+
+	c, err := client.New(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create factory client for %q: %w", baseURL, err)
+	}
+
+	return c, nil
+}
+
+// GetByID reads a schematic from the factory that built the boot media it
+// describes. An empty factoryBaseURL means the configured factory.
+func (svc *Service) GetByID(ctx context.Context, id, factoryBaseURL string) (*schematic.Schematic, error) {
+	factoryClient, err := svc.clientFor(factoryBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Coalesced per factory and ID, never by ID alone: on a miss the flight's result
+	// is that one factory's answer, and handing its 404 to a caller asking a
+	// different factory would fail a read that factory could have served. The disk
+	// cache below stays keyed by ID alone, since a schematic ID is the hash of the
+	// schematic's canonical form, so any factory holding it holds the same content.
+	ch := svc.sf.DoChan(factoryClient.BaseURL()+" "+id, func() (any, error) {
+		return svc.getByID(ctx, id, factoryClient)
 	})
 
 	var res singleflight.Result
@@ -108,12 +164,14 @@ func (svc *Service) GetByID(ctx context.Context, id string) (*schematic.Schemati
 	return sch, nil
 }
 
-func (svc *Service) getByID(ctx context.Context, id string) (*schematic.Schematic, error) {
-	if err := os.MkdirAll(svc.cacheDir, 0o755); err != nil {
+func (svc *Service) getByID(ctx context.Context, id string, factoryClient *client.Client) (*schematic.Schematic, error) {
+	// Schematics can carry a join token, so the cache is kept readable only by the
+	// user running the emulator.
+	if err := os.MkdirAll(svc.cacheDir, 0o700); err != nil {
 		return nil, err
 	}
 
-	svc.logger.Info("get schematic", zap.String("id", id))
+	svc.logger.Info("get schematic", zap.String("id", id), zap.String("factory", factoryClient.BaseURL()))
 
 	filePath := filepath.Join(svc.cacheDir, id+".yaml")
 
@@ -128,16 +186,16 @@ func (svc *Service) getByID(ctx context.Context, id string) (*schematic.Schemati
 		return nil, fmt.Errorf("failed to read schematic file %q: %w", filePath, readErr)
 	}
 
-	svc.logger.Info("cache miss, download schematic", zap.String("id", id))
+	svc.logger.Info("cache miss, download schematic", zap.String("id", id), zap.String("factory", factoryClient.BaseURL()))
 
 	// doesn't exist, get schematic
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	schematic, err := svc.factoryClient.SchematicGet(ctx, id)
+	schematic, err := factoryClient.SchematicGet(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get schematic from factory: %w", err)
+		return nil, fmt.Errorf("failed to get schematic from factory %s: %w", factoryClient.BaseURL(), err)
 	}
 
 	rawSchematic, err := schematic.Marshal()
@@ -147,7 +205,7 @@ func (svc *Service) getByID(ctx context.Context, id string) (*schematic.Schemati
 
 	destFile := filepath.Join(svc.cacheDir, id+".yaml.tmp")
 
-	if err = os.WriteFile(destFile, rawSchematic, 0o644); err != nil {
+	if err = os.WriteFile(destFile, rawSchematic, 0o600); err != nil {
 		return nil, fmt.Errorf("failed to write schematic file %q: %w", destFile, err)
 	}
 

--- a/internal/pkg/schematic/schematic_test.go
+++ b/internal/pkg/schematic/schematic_test.go
@@ -6,6 +6,9 @@ package schematic_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,7 +61,7 @@ func TestGetByID(t *testing.T) {
 
 	before := time.Now()
 
-	sch, err := schematicService.GetByID(ctx, expectedID)
+	sch, err := schematicService.GetByID(ctx, expectedID, "")
 	require.NoError(t, err)
 
 	after := time.Now()
@@ -70,7 +73,7 @@ func TestGetByID(t *testing.T) {
 
 	before = time.Now()
 
-	sch, err = schematicService.GetByID(ctx, expectedID)
+	sch, err = schematicService.GetByID(ctx, expectedID, "")
 	require.NoError(t, err)
 
 	after = time.Now()
@@ -88,4 +91,125 @@ func TestGetByID(t *testing.T) {
 	assert.Equal(t, marshaled1, marshaled2)
 
 	logger.Info("schematic", zap.ByteString("data", marshaled2), zap.Duration("duration", after.Sub(before)))
+}
+
+// TestGetByIDPerFactory asserts that a schematic is read from the factory that
+// holds it, rather than always from the configured one.
+//
+// It deliberately does NOT assert that the same identifier can mean different
+// things at different factories: an identifier is the hash of the schematic's
+// canonical form, so that cannot happen, and the cache is keyed by identifier
+// alone for exactly that reason.
+func TestGetByIDPerFactory(t *testing.T) {
+	t.Parallel()
+
+	var configuredHits, otherHits int
+
+	body := "customization:\n    extraKernelArgs:\n        - foo=bar\n"
+
+	configured := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		configuredHits++
+
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(configured.Close)
+
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		otherHits++
+
+		w.Write([]byte(body)) //nolint:errcheck
+	}))
+	t.Cleanup(other.Close)
+
+	const (
+		configuredID = "1111111111111111111111111111111111111111111111111111111111111111"
+		otherID      = "2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	service, err := schematicsvc.NewService(t.TempDir(), configured.URL, "", "", zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	// The configured factory, reached by empty string, by its own URL, and by a
+	// trailing-slash spelling of it, which must not be mistaken for another factory.
+	for _, factory := range []string{"", configured.URL, configured.URL + "/"} {
+		_, getErr := service.GetByID(t.Context(), configuredID, factory)
+		require.NoError(t, getErr)
+	}
+
+	assert.Equal(t, 1, configuredHits, "cached after the first read, and every spelling is the same factory")
+	assert.Equal(t, 0, otherHits)
+
+	// An identifier the configured factory does not hold is read from the factory
+	// that does.
+	_, err = service.GetByID(t.Context(), otherID, other.URL)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, otherHits, "the other factory should have been asked")
+	assert.Equal(t, 1, configuredHits, "and the configured one should not have been asked again")
+
+	// Cached content is reused whichever factory is named, since the identifier
+	// determines the content.
+	_, err = service.GetByID(t.Context(), otherID, configured.URL)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, otherHits)
+	assert.Equal(t, 1, configuredHits)
+}
+
+// TestGetByIDConcurrentFactories asserts that concurrent reads of the same
+// identifier from different factories are answered by their own factory. Were
+// the reads coalesced by identifier alone, one factory's "not found" would be
+// handed to a caller that asked a factory which holds the schematic.
+func TestGetByIDConcurrentFactories(t *testing.T) {
+	t.Parallel()
+
+	const id = "3333333333333333333333333333333333333333333333333333333333333333"
+
+	var (
+		notFoundEntered  = make(chan struct{})
+		notFoundContinue = make(chan struct{})
+	)
+
+	// Released in cleanup as well, so that a failure between the block and the
+	// release does not leave the handler stuck and the server unable to close.
+	releaseNotFound := sync.OnceFunc(func() { close(notFoundContinue) })
+
+	notFoundFactory := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(notFoundEntered)
+		<-notFoundContinue
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(notFoundFactory.Close)
+	t.Cleanup(releaseNotFound)
+
+	holdingFactory := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("customization:\n    extraKernelArgs:\n        - foo=bar\n")) //nolint:errcheck
+	}))
+	t.Cleanup(holdingFactory.Close)
+
+	service, err := schematicsvc.NewService(t.TempDir(), notFoundFactory.URL, "", "", zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	notFoundResult := make(chan error, 1)
+
+	go func() {
+		_, getErr := service.GetByID(t.Context(), id, "")
+		notFoundResult <- getErr
+	}()
+
+	// The first read is now blocked inside the factory that does not hold the
+	// schematic. A read from the factory that does must not be joined onto it.
+	// Bounded so that a regression fails the test instead of deadlocking it.
+	<-notFoundEntered
+
+	boundedCtx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	_, err = service.GetByID(boundedCtx, id, holdingFactory.URL)
+	require.NoError(t, err)
+
+	releaseNotFound()
+
+	require.Error(t, <-notFoundResult, "the factory that does not hold the schematic still reports the miss")
 }


### PR DESCRIPTION
Static mode derived a schematic from the kernel args it was given and then asked an image factory to hand that schematic back, but nothing ever submitted it, so the factory had never seen it and the read failed. The controllers that report a machine's extensions and its kernel command line failed with it, permanently. The documented way to run static mode hit this every time, because it uses the kernel args of one particular Omni instance.

A schematic is the identity of media that a factory built, so it is an input rather than something to derive. Static mode now takes the schematic of the media its machines pretend to have booted, reads it once at startup, and fails immediately when the factory does not have it. Media built without a factory has no schematic and stays supported by giving the kernel args and the extensions directly.

Boot media info is optional altogether. SideroLink is optional in Talos, so machines given neither a schematic nor kernel args, or media whose kernel args carry no join parameters, run standalone and join nothing.

Schematic reads also go to the factory a machine's media actually came from, rather than always the one the emulator was started with, so machines booted from another factory can resolve their schematic at all. Concurrent reads of the same schematic from different factories are answered independently, so one factory's miss is never handed to a caller asking a factory that holds it.

Verified against a live Omni instance both ways, including an unresolvable schematic and a restart onto different media, and standalone machines were verified to run cleanly with no boot media info at all.
