### PR TITLE
feat: allow giving emulated machines additional disks

### DIFF
--- a/cmd/talemu/main.go
+++ b/cmd/talemu/main.go
@@ -40,6 +40,10 @@ var rootCmd = &cobra.Command{
 	Long:         `Can simulate as many nodes as you want`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if cfg.extraDisks < 0 || cfg.extraDisks > machine.MaxExtraDisks {
+			return fmt.Errorf("--extra-disks must be between 0 and %d, got %d", machine.MaxExtraDisks, cfg.extraDisks)
+		}
+
 		params, err := machine.ParseKernelArgs(cfg.kernelArgs)
 		if err != nil {
 			return err
@@ -120,7 +124,8 @@ var rootCmd = &cobra.Command{
 
 			eg.Go(func() error {
 				return m.Run(ctx, params, i+1000, kubernetes, machine.WithNetworkClient(nc), machine.WithTalosVersion(cfg.talosVersion),
-					machine.WithSchematic(initialSchematicID), machine.WithNodeProxyingDisabled(cfg.nodeProxyingDisabled))
+					machine.WithSchematic(initialSchematicID), machine.WithNodeProxyingDisabled(cfg.nodeProxyingDisabled),
+					machine.WithExtraDisks(cfg.extraDisks))
 			})
 
 			machines = append(machines, m)
@@ -190,6 +195,7 @@ var cfg struct {
 	imageFactoryBaseURL  string
 	extensions           []string
 	machinesCount        int
+	extraDisks           int
 	nodeProxyingDisabled bool
 }
 
@@ -213,6 +219,8 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.schematicCacheDir, "schematic-cache-dir", "/tmp/talemu-schematics", "the directory to use for caching schematics")
 	rootCmd.Flags().StringVar(&cfg.imageFactoryBaseURL, "image-factory-base-url", emuconst.DefaultImageFactoryBaseURL, "base URL of the image factory")
 	rootCmd.Flags().IntVar(&cfg.machinesCount, "machines", 1, "the number of machines to emulate")
+	rootCmd.Flags().IntVar(&cfg.extraDisks, "extra-disks", 0,
+		fmt.Sprintf("the number of additional empty disks to give each machine, named vdb onwards (max %d)", machine.MaxExtraDisks))
 	rootCmd.Flags().BoolVar(&cfg.nodeProxyingDisabled, "disable-node-proxying", false,
 		"disable node-to-node proxying in apid: rejects the 'node' header, validates that a single-entry 'nodes' header targets this node, multi-node 'nodes' is still proxied")
 }

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	golang.org/x/sys v0.46.0
 	golang.org/x/time v0.15.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3/go.mod h1:Z4WJ5pJOYWFWcHEQUelD5QaZDknIQkpIL/+fyJOT9+A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260615183401-62b3387ff324 h1:9HZDLIdYBJXAnaFOr9WHrKVycfpY+75s9HGadC0305A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260615183401-62b3387ff324/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/pkg/grpc/middleware/auth/basic/basic.go
+++ b/internal/pkg/grpc/middleware/auth/basic/basic.go
@@ -46,7 +46,6 @@ func NewConnection(dialer func(ctx context.Context, addr string) (net.Conn, erro
 	grpcOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithPerRPCCredentials(creds),
-		grpc.WithSharedWriteBuffer(true),
 		grpc.WithContextDialer(dialer),
 	}
 

--- a/internal/pkg/kubefactory/etcd.go
+++ b/internal/pkg/kubefactory/etcd.go
@@ -105,7 +105,6 @@ func NewEmbeddedEtcd(ctx context.Context, path string, logger *zap.Logger) (*Etc
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize)),
-			grpc.WithSharedWriteBuffer(true),
 		},
 		Logger: logger.WithOptions(
 			// never enable debug logs for etcd client, they are too chatty

--- a/internal/pkg/machine/blocklayout/blocklayout.go
+++ b/internal/pkg/machine/blocklayout/blocklayout.go
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package blocklayout builds the emulated partition layout of a machine's system disk,
+// so that the discovered volumes, the volume statuses and the mount statuses all
+// describe the same disk: the one Talos was installed to.
+package blocklayout
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+)
+
+// DiskSize is the size of every emulated disk.
+const DiskSize = 50 * 1024 * 1024 * 1024
+
+// Partition indexes of the layout, shared with the mount statuses which point at
+// "<system disk dev path><index>".
+const (
+	StatePartitionIndex     = 4
+	EphemeralPartitionIndex = 5
+)
+
+const (
+	partType = "part"
+
+	ephemeralOffset = 304 * 1024 * 1024
+	ephemeralSize   = DiskSize - ephemeralOffset
+)
+
+// Build returns the discovered volumes and volume statuses describing a Talos
+// installation on the given disk.
+func Build(diskName string) []resource.Resource {
+	devPath := "/dev/" + diskName
+
+	partition := func(index int, label string, offset, size uint64) *block.DiscoveredVolume {
+		name := fmt.Sprintf("%s%d", diskName, index)
+
+		volume := block.NewDiscoveredVolume(block.NamespaceName, name)
+		volume.TypedSpec().Type = partType
+		volume.TypedSpec().DevPath = fmt.Sprintf("%s%d", devPath, index)
+		volume.TypedSpec().DevicePath = volume.TypedSpec().DevPath
+		volume.TypedSpec().Parent = diskName
+		volume.TypedSpec().ParentDevPath = devPath
+		volume.TypedSpec().Name = name
+		volume.TypedSpec().PartitionLabel = label
+		volume.TypedSpec().PartitionIndex = uint(index)
+		volume.TypedSpec().Offset = offset
+		volume.TypedSpec().SetSize(size)
+
+		return volume
+	}
+
+	volumeStatus := func(index int, label, mountLocation string, size uint64) *block.VolumeStatus {
+		volume := block.NewVolumeStatus(block.NamespaceName, label)
+		volume.TypedSpec().Phase = block.VolumePhaseReady
+		volume.TypedSpec().Type = block.VolumeTypePartition
+		volume.TypedSpec().Location = fmt.Sprintf("%s%d", devPath, index)
+		volume.TypedSpec().MountLocation = mountLocation
+		volume.TypedSpec().ParentLocation = devPath
+		volume.TypedSpec().PartitionIndex = index
+		volume.TypedSpec().Filesystem = block.FilesystemTypeXFS
+		volume.TypedSpec().SetSize(size)
+
+		return volume
+	}
+
+	return []resource.Resource{
+		partition(1, "EFI", 1024*1024, 100*1024*1024),
+		partition(2, "BOOT", 101*1024*1024, 100*1024*1024),
+		partition(3, "META", 202*1024*1024, 2*1024*1024),
+		partition(StatePartitionIndex, constants.StatePartitionLabel, 204*1024*1024, 100*1024*1024),
+		partition(EphemeralPartitionIndex, constants.EphemeralPartitionLabel, ephemeralOffset, ephemeralSize),
+		volumeStatus(StatePartitionIndex, constants.StatePartitionLabel, "/system/state", 100*1024*1024),
+		volumeStatus(EphemeralPartitionIndex, constants.EphemeralPartitionLabel, "/var", ephemeralSize),
+	}
+}
+
+// Move places the emulated partition layout onto the given disk, removing it from
+// whatever disk held it before. Used when installing, since the machines are seeded
+// with the layout on their boot disk while the install can target any disk.
+func Move(ctx context.Context, st state.State, diskName string) error {
+	volumes, err := safe.StateListAll[*block.DiscoveredVolume](ctx, st)
+	if err != nil {
+		return err
+	}
+
+	for volume := range volumes.All() {
+		if volume.TypedSpec().Type != partType {
+			continue
+		}
+
+		if err = st.Destroy(ctx, volume.Metadata()); err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+	}
+
+	for _, label := range []string{constants.StatePartitionLabel, constants.EphemeralPartitionLabel} {
+		if err = st.Destroy(ctx, block.NewVolumeStatus(block.NamespaceName, label).Metadata()); err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+	}
+
+	for _, res := range Build(diskName) {
+		if err = st.Create(ctx, res); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/machine/controllers/machine_status.go
+++ b/internal/pkg/machine/controllers/machine_status.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	emuconst "github.com/siderolabs/talemu/internal/pkg/constants"
+	"github.com/siderolabs/talemu/internal/pkg/machine/blocklayout"
 	"github.com/siderolabs/talemu/internal/pkg/machine/machineconfig"
 	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
 )
@@ -235,6 +236,12 @@ func (ctrl *MachineStatusController) reconcile(ctx context.Context, r controller
 	// this instead of an explicit LifecycleService.Install, so without it the machine keeps reporting
 	// its boot version and never reaches the target the cluster was created with.
 	if err = ctrl.setInstalledImage(ctx, installConfig.Image()); err != nil {
+		return err
+	}
+
+	// The install writes the partition layout to its target disk, so the block
+	// resources move there, keeping them all describing the same disk.
+	if err = blocklayout.Move(ctx, ctrl.State, installDisk.Metadata().ID()); err != nil {
 		return err
 	}
 

--- a/internal/pkg/machine/controllers/mount_status.go
+++ b/internal/pkg/machine/controllers/mount_status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/talemu/internal/pkg/machine/blocklayout"
 	"github.com/siderolabs/talemu/internal/pkg/machine/machineconfig"
 )
 
@@ -71,6 +72,8 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 		case <-r.EventCh():
 		}
 
+		// The indexes match the emulated partition layout, so the mount sources point
+		// at partitions the discovered volumes actually describe.
 		statuses := []struct {
 			label  string
 			target string
@@ -78,12 +81,12 @@ func (ctrl *MountStatusController) Run(ctx context.Context, r controller.Runtime
 		}{
 			{
 				label:  constants.EphemeralPartitionLabel,
-				index:  6,
+				index:  blocklayout.EphemeralPartitionIndex,
 				target: "/var",
 			},
 			{
 				label:  constants.StatePartitionLabel,
-				index:  5,
+				index:  blocklayout.StatePartitionIndex,
 				target: "/system/state",
 			},
 		}

--- a/internal/pkg/machine/controllers/siderolink.go
+++ b/internal/pkg/machine/controllers/siderolink.go
@@ -334,7 +334,6 @@ func (ctrl *ManagerController) provision(ctx context.Context, r controller.Runti
 		conn, connErr := grpc.NewClient(
 			cfg.TypedSpec().Host,
 			withTransportCredentials(cfg.TypedSpec().Insecure),
-			grpc.WithSharedWriteBuffer(true),
 		)
 		if connErr != nil {
 			return nil, fmt.Errorf("error dialing SideroLink endpoint %q: %w", cfg.TypedSpec().Host, connErr)

--- a/internal/pkg/machine/events/events.go
+++ b/internal/pkg/machine/events/events.go
@@ -152,7 +152,6 @@ func (h *Handler) startEventSink(ctx context.Context, logger *zap.Logger, endpoi
 	conn, err := grpc.NewClient(
 		endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithSharedWriteBuffer(true),
 		grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
 			var dialer net.Dialer
 

--- a/internal/pkg/machine/machine.go
+++ b/internal/pkg/machine/machine.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/siderolabs/talemu/internal/pkg/constants"
 	"github.com/siderolabs/talemu/internal/pkg/kubefactory"
+	"github.com/siderolabs/talemu/internal/pkg/machine/blocklayout"
 	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
 	"github.com/siderolabs/talemu/internal/pkg/machine/events"
 	"github.com/siderolabs/talemu/internal/pkg/machine/logging"
@@ -39,16 +40,51 @@ import (
 )
 
 const (
-	diskDevName      = "vda"
-	diskDevPath      = "/dev/vda"
-	diskPartType     = "part"
-	stateDevPath     = "/dev/vda4"
-	ephemeralDevPath = "/dev/vda5"
+	diskDevName = "vda"
+	diskDevPath = "/dev/vda"
 
-	diskSize        = 50 * 1024 * 1024 * 1024
-	ephemeralOffset = 304 * 1024 * 1024
-	ephemeralSize   = diskSize - ephemeralOffset
+	diskSize = blocklayout.DiskSize
 )
+
+// MaxExtraDisks is the number of additional disks a machine can be given, capped
+// so the device names stay in the single-letter vdb..vdz range.
+const MaxExtraDisks = 25
+
+// extraDisks builds count additional empty disks, named vdb, vdc and so on.
+//
+// They carry no partitions, so the machine has somewhere to install to that is
+// not the disk it booted from.
+//
+// Callers are expected to keep count within 0..MaxExtraDisks, which the command
+// line enforces, since the naming scheme only has single letters to work with.
+func extraDisks(count int) []resource.Resource {
+	resources := make([]resource.Resource, 0, count*2)
+
+	for i := range count {
+		name := fmt.Sprintf("vd%c", 'b'+i)
+		devPath := "/dev/" + name
+
+		disk := block.NewDisk(block.NamespaceName, name)
+		disk.TypedSpec().Size = diskSize
+		disk.TypedSpec().Model = "CM5514"
+		disk.TypedSpec().Transport = "virtio"
+		disk.TypedSpec().Rotational = true
+		disk.TypedSpec().BusPath = fmt.Sprintf("/pci0000:00/0000:00:05.0/0000:01:01.0/virtio2/host2/target2:0:0/2:0:%d:0/", i+1)
+
+		discovered := block.NewDiscoveredVolume(block.NamespaceName, name)
+		discovered.TypedSpec().Type = "disk"
+		discovered.TypedSpec().DevPath = devPath
+		discovered.TypedSpec().DevicePath = devPath
+		discovered.TypedSpec().Name = name
+		discovered.TypedSpec().SetSize(diskSize)
+		discovered.TypedSpec().SectorSize = 512
+		discovered.TypedSpec().IOSize = 512
+
+		resources = append(resources, disk, discovered)
+	}
+
+	return resources
+}
 
 // Machine is a single Talos machine.
 type Machine struct {
@@ -201,86 +237,6 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 	discoveredDisk.TypedSpec().SectorSize = 512
 	discoveredDisk.TypedSpec().IOSize = 512
 
-	discoveredEfi := block.NewDiscoveredVolume(block.NamespaceName, "vda1")
-	discoveredEfi.TypedSpec().Type = diskPartType
-	discoveredEfi.TypedSpec().DevPath = "/dev/vda1"
-	discoveredEfi.TypedSpec().DevicePath = "/dev/vda1"
-	discoveredEfi.TypedSpec().Parent = diskDevName
-	discoveredEfi.TypedSpec().ParentDevPath = diskDevPath
-	discoveredEfi.TypedSpec().Name = "vda1"
-	discoveredEfi.TypedSpec().PartitionLabel = "EFI"
-	discoveredEfi.TypedSpec().PartitionIndex = 1
-	discoveredEfi.TypedSpec().Offset = 1024 * 1024
-	discoveredEfi.TypedSpec().SetSize(100 * 1024 * 1024)
-
-	discoveredBoot := block.NewDiscoveredVolume(block.NamespaceName, "vda2")
-	discoveredBoot.TypedSpec().Type = diskPartType
-	discoveredBoot.TypedSpec().DevPath = "/dev/vda2"
-	discoveredBoot.TypedSpec().DevicePath = "/dev/vda2"
-	discoveredBoot.TypedSpec().Parent = diskDevName
-	discoveredBoot.TypedSpec().ParentDevPath = diskDevPath
-	discoveredBoot.TypedSpec().Name = "vda2"
-	discoveredBoot.TypedSpec().PartitionLabel = "BOOT"
-	discoveredBoot.TypedSpec().PartitionIndex = 2
-	discoveredBoot.TypedSpec().Offset = 101 * 1024 * 1024
-	discoveredBoot.TypedSpec().SetSize(100 * 1024 * 1024)
-
-	discoveredMeta := block.NewDiscoveredVolume(block.NamespaceName, "vda3")
-	discoveredMeta.TypedSpec().Type = diskPartType
-	discoveredMeta.TypedSpec().DevPath = "/dev/vda3"
-	discoveredMeta.TypedSpec().DevicePath = "/dev/vda3"
-	discoveredMeta.TypedSpec().Parent = diskDevName
-	discoveredMeta.TypedSpec().ParentDevPath = diskDevPath
-	discoveredMeta.TypedSpec().Name = "vda3"
-	discoveredMeta.TypedSpec().PartitionLabel = "META"
-	discoveredMeta.TypedSpec().PartitionIndex = 3
-	discoveredMeta.TypedSpec().Offset = 202 * 1024 * 1024
-	discoveredMeta.TypedSpec().SetSize(2 * 1024 * 1024)
-
-	discoveredState := block.NewDiscoveredVolume(block.NamespaceName, "vda4")
-	discoveredState.TypedSpec().Type = diskPartType
-	discoveredState.TypedSpec().DevPath = stateDevPath
-	discoveredState.TypedSpec().DevicePath = stateDevPath
-	discoveredState.TypedSpec().Parent = diskDevName
-	discoveredState.TypedSpec().ParentDevPath = diskDevPath
-	discoveredState.TypedSpec().Name = "vda4"
-	discoveredState.TypedSpec().PartitionLabel = "STATE"
-	discoveredState.TypedSpec().PartitionIndex = 4
-	discoveredState.TypedSpec().Offset = 204 * 1024 * 1024
-	discoveredState.TypedSpec().SetSize(100 * 1024 * 1024)
-
-	discoveredEphemeral := block.NewDiscoveredVolume(block.NamespaceName, "vda5")
-	discoveredEphemeral.TypedSpec().Type = diskPartType
-	discoveredEphemeral.TypedSpec().DevPath = ephemeralDevPath
-	discoveredEphemeral.TypedSpec().DevicePath = ephemeralDevPath
-	discoveredEphemeral.TypedSpec().Parent = diskDevName
-	discoveredEphemeral.TypedSpec().ParentDevPath = diskDevPath
-	discoveredEphemeral.TypedSpec().Name = "vda5"
-	discoveredEphemeral.TypedSpec().PartitionLabel = "EPHEMERAL"
-	discoveredEphemeral.TypedSpec().PartitionIndex = 5
-	discoveredEphemeral.TypedSpec().Offset = ephemeralOffset
-	discoveredEphemeral.TypedSpec().SetSize(ephemeralSize)
-
-	volumeState := block.NewVolumeStatus(block.NamespaceName, "STATE")
-	volumeState.TypedSpec().Phase = block.VolumePhaseReady
-	volumeState.TypedSpec().Type = block.VolumeTypePartition
-	volumeState.TypedSpec().Location = stateDevPath
-	volumeState.TypedSpec().MountLocation = "/system/state"
-	volumeState.TypedSpec().ParentLocation = diskDevPath
-	volumeState.TypedSpec().PartitionIndex = 4
-	volumeState.TypedSpec().Filesystem = block.FilesystemTypeXFS
-	volumeState.TypedSpec().SetSize(100 * 1024 * 1024)
-
-	volumeEphemeral := block.NewVolumeStatus(block.NamespaceName, "EPHEMERAL")
-	volumeEphemeral.TypedSpec().Phase = block.VolumePhaseReady
-	volumeEphemeral.TypedSpec().Type = block.VolumeTypePartition
-	volumeEphemeral.TypedSpec().Location = ephemeralDevPath
-	volumeEphemeral.TypedSpec().MountLocation = "/var"
-	volumeEphemeral.TypedSpec().ParentLocation = diskDevPath
-	volumeEphemeral.TypedSpec().PartitionIndex = 5
-	volumeEphemeral.TypedSpec().Filesystem = block.FilesystemTypeXFS
-	volumeEphemeral.TypedSpec().SetSize(ephemeralSize)
-
 	pciNet := hardware.NewPCIDeviceInfo("0000:00:01.0")
 	pciNet.TypedSpec().Class = "Network controller"
 	pciNet.TypedSpec().Subclass = "Ethernet controller"
@@ -316,16 +272,14 @@ func (m *Machine) Run(ctx context.Context, siderolinkParams *SideroLinkParams, s
 		defaultRoute,
 		memory,
 		discoveredDisk,
-		discoveredEfi,
-		discoveredBoot,
-		discoveredMeta,
-		discoveredState,
-		discoveredEphemeral,
-		volumeState,
-		volumeEphemeral,
 		pciNet,
 		pciDisk,
 	)
+
+	// The machines are seeded with the partition layout on the boot disk. An install
+	// can target any disk, at which point the layout moves there.
+	resources = append(resources, blocklayout.Build(diskDevName)...)
+	resources = append(resources, extraDisks(opts.extraDisks)...)
 
 	if opts.schematic != "" || opts.talosVersion != "" {
 		image := talos.NewImage(talos.NamespaceName, talos.ImageID)

--- a/internal/pkg/machine/options.go
+++ b/internal/pkg/machine/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	talosVersion         string
 	schematic            string
 	bootFactoryURL       string
+	extraDisks           int
 	secureBoot           bool
 	nodeProxyingDisabled bool
 }
@@ -69,5 +70,16 @@ func WithNodeProxyingDisabled(value bool) Option {
 func WithBootFactoryURL(value string) Option {
 	return func(o *Options) {
 		o.bootFactoryURL = value
+	}
+}
+
+// WithExtraDisks gives the machine additional empty disks beyond the system one,
+// named vdb, vdc and so on.
+//
+// A machine with a single disk offers nothing to choose from, so anything that
+// selects an install disk cannot be exercised against it.
+func WithExtraDisks(count int) Option {
+	return func(o *Options) {
+		o.extraDisks = count
 	}
 }

--- a/internal/pkg/machine/services/apid.go
+++ b/internal/pkg/machine/services/apid.go
@@ -155,7 +155,6 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 				proxy.WithStreamedDetector(router.StreamedDetector),
 			),
 		),
-		grpc.SharedWriteBuffer(true),
 	}
 
 	s := grpc.NewServer(
@@ -175,7 +174,6 @@ func (apid *APID) Run(ctx context.Context, endpoint netip.Prefix, logger *zap.Lo
 	localServer := grpc.NewServer(
 		grpc.Creds(insecure.NewCredentials()),
 		grpc.ForceServerCodecV2(proxy.Codec()),
-		grpc.SharedWriteBuffer(true),
 		grpc.ChainUnaryInterceptor(recovery.UnaryServerInterceptor(recoveryOption)),
 		grpc.ChainStreamInterceptor(recovery.StreamServerInterceptor(recoveryOption)),
 	)

--- a/internal/pkg/machine/services/apid/pkg/backend/apid.go
+++ b/internal/pkg/machine/services/apid/pkg/backend/apid.go
@@ -115,7 +115,6 @@ func (a *APID) GetConnection(ctx context.Context, _ string) (context.Context, *g
 			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
 		),
 		grpc.WithDefaultCallOptions(grpc.ForceCodecV2(proxy.Codec())),
-		grpc.WithSharedWriteBuffer(true),
 	)
 
 	return outCtx, a.conn, err

--- a/internal/pkg/machine/services/apid/pkg/backend/local.go
+++ b/internal/pkg/machine/services/apid/pkg/backend/local.go
@@ -65,7 +65,6 @@ func (l *Local) GetConnection(ctx context.Context, _ string) (context.Context, *
 			grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize),
 		),
 		grpc.WithDefaultCallOptions(grpc.ForceCodecV2(proxy.Codec())),
-		grpc.WithSharedWriteBuffer(true),
 		// Disable idle mode: this is a permanent in-process loopback connection,
 		// so there is nothing to reclaim by going idle, and it avoids the
 		// first-request latency of re-establishing the connection after a quiet

--- a/internal/pkg/machine/services/lifecycle.go
+++ b/internal/pkg/machine/services/lifecycle.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/talemu/internal/pkg/machine/blocklayout"
 )
 
 // LifecycleService is a GRPC service emulating the behavior of the Talos lifecycle service.
@@ -71,6 +73,12 @@ func (s *LifecycleService) Install(req *machine.LifecycleServiceInstallRequest, 
 	}
 
 	if _, err = setImage(ctx, s.state, s.imageFactoryHost, image); err != nil {
+		return err
+	}
+
+	// The install writes the partition layout to its target disk, so the block
+	// resources move there, keeping them all describing the same disk.
+	if err = blocklayout.Move(ctx, s.state, filepath.Base(disk)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Emulated machines had exactly one disk, which made anything that picks an install target impossible to exercise against them: with a single candidate there is no non-default choice to make, and Omni's install disk selector offers only that one disk.

Machines can now be given additional empty disks, named from vdb onwards. They carry no partitions, so the disk the machine booted from keeps the system partitions and the extra ones are available as install targets. The count is capped so the device names stay in the single-letter range.

Installing onto one of the extra disks used to leave the block resources describing two different layouts, with the system disk moving to the install target while the partitions and volume statuses stayed on the boot disk. The partition layout now moves to the disk that was installed to, and the mount statuses point at partition indexes the layout actually has, so all block resources describe the same disk. Closes #77.

Also updates the grpc module past the release the dependency scan in CI fails on, dropping the shared write buffer options it deprecates in favor of that being the default behavior.


