### PR TITLE
fix: derive the node addresses from the address statuses

### DIFF
--- a/internal/pkg/machine/controllers/node_address.go
+++ b/internal/pkg/machine/controllers/node_address.go
@@ -38,7 +38,7 @@ func (ctrl *NodeAddressController) Inputs() []controller.Input {
 	return []controller.Input{
 		{
 			Namespace: network.NamespaceName,
-			Type:      network.AddressSpecType,
+			Type:      network.AddressStatusType,
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -67,16 +67,15 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 		case <-r.EventCh():
 		}
 
-		addresses, err := safe.ReaderListAll[*network.AddressSpec](ctx, r)
+		// Node addresses derive from the address statuses, matching real Talos: they reflect what is actually assigned on the interfaces.
+		addresses, err := safe.ReaderListAll[*network.AddressStatus](ctx, r)
 		if err != nil {
 			return err
 		}
 
-		// Collect all real addresses from AddressSpec resources (includes SideroLink, etc.),
-		// matching real Talos behavior where NodeAddressCurrent contains all current interface addresses.
 		realAddrs := make([]netip.Prefix, 0, addresses.Len())
 
-		addresses.ForEach(func(r *network.AddressSpec) {
+		addresses.ForEach(func(r *network.AddressStatus) {
 			realAddrs = append(realAddrs, r.TypedSpec().Address)
 		})
 
@@ -101,18 +100,12 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 		}
 
 		if err = safe.WriterModify(ctx, r, network.NewNodeAddress(network.NamespaceName, network.NodeAddressDefaultID), func(r *network.NodeAddress) error {
-			addrs := make([]netip.Prefix, 0, addresses.Len())
-
-			addresses.ForEach(func(r *network.AddressSpec) {
-				addrs = append(addrs, r.TypedSpec().Address)
-			})
-
-			r.TypedSpec().Addresses = addrs
+			r.TypedSpec().Addresses = realAddrs
 
 			_, err = safe.StateUpdateWithConflicts(
 				ctx, ctrl.GlobalState, emu.NewMachineStatus(emu.NamespaceName, ctrl.MachineID).Metadata(),
 				func(cm *emu.MachineStatus) error {
-					cm.TypedSpec().Value.Addresses = xslices.Map(addrs, func(p netip.Prefix) string {
+					cm.TypedSpec().Value.Addresses = xslices.Map(realAddrs, func(p netip.Prefix) string {
 						return p.Addr().String()
 					})
 
@@ -126,15 +119,9 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 		}
 
 		if err = safe.WriterModify(ctx, r, k8s.NewNodeIP(k8s.NamespaceName, k8s.KubeletID), func(r *k8s.NodeIP) error {
-			addrs := make([]netip.Addr, 0, addresses.Len())
+			r.TypedSpec().Addresses = xslices.Map(realAddrs, netip.Prefix.Addr)
 
-			addresses.ForEach(func(r *network.AddressSpec) {
-				addrs = append(addrs, r.TypedSpec().Address.Addr())
-			})
-
-			r.TypedSpec().Addresses = addrs
-
-			return err
+			return nil
 		}); err != nil {
 			return err
 		}

--- a/internal/pkg/machine/controllers/static_pods.go
+++ b/internal/pkg/machine/controllers/static_pods.go
@@ -127,6 +127,10 @@ func (ctrl *StaticPodController) reconcile(ctx context.Context, r controller.Run
 		return err
 	}
 
+	if len(address.TypedSpec().Addresses) == 0 {
+		return nil
+	}
+
 	nodename, err := safe.ReaderGetByID[*k8s.Nodename](ctx, r, k8s.NodenameID)
 	if err != nil {
 		if state.IsNotFoundError(err) {

--- a/internal/pkg/machine/runtime/runtime.go
+++ b/internal/pkg/machine/runtime/runtime.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	netres "github.com/siderolabs/talos/pkg/machinery/resources/network"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -53,7 +55,11 @@ func NewRuntime(ctx context.Context, logger *zap.Logger, slot int, id string, gl
 		return nil, fmt.Errorf("failed to create state directories %w", err)
 	}
 
-	st, backingStore, err := NewState(filepath.Join(stateDir, "state.db"), logger)
+	// The network namespace is kept in-memory: like in real Talos, its resources are runtime-derived and must not survive a reboot.
+	st, backingStore, err := NewState(
+		filepath.Join(stateDir, "state.db"), logger,
+		NamespacedState{Namespace: netres.NamespaceName, State: state.WrapCore(inmem.NewState(netres.NamespaceName))},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create state %w", err)
 	}


### PR DESCRIPTION
The node address lists were built from the address configuration intents, so an address that was in the process of being removed, for example after the SideroLink connection came back with a new address, could stay on the lists indefinitely and keep the derived Kubernetes secrets, certificates and kubeconfigs pinned to a dead address. The lists are now derived from the address statuses, which the rest of the emulation already uses and which reflect what is actually assigned.

The network state is no longer persisted across emulator restarts, matching real Talos where it is derived at runtime. This also prevents an interrupted address removal from surviving a restart as an undeletable leftover that blocks re-establishing the SideroLink connection. The static pod renderer now tolerates an empty node address list, which briefly happens at boot.