### PR TITLE
feat: add a magic kernel arg that makes a machine act broken

### DIFF
--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -37,3 +37,9 @@ const ImageFactoryUsernameEnv = "TALEMU_IMAGE_FACTORY_USERNAME"
 // ImageFactoryPasswordEnv is the environment variable carrying the optional basic auth password for the
 // image factory. See [ImageFactoryUsernameEnv].
 const ImageFactoryPasswordEnv = "TALEMU_IMAGE_FACTORY_PASSWORD"
+
+// StuckBootingKernelArg is a magic kernel arg that makes the emulated machine act broken as long as the
+// arg is part of its boot media: the machine stays in the booting stage, never reports ready, and its
+// Kubernetes node reports not ready. It simulates a machine broken by a bad kernel args or extensions
+// change, and the machine recovers when a schematic without the arg is installed.
+const StuckBootingKernelArg = "talemu.stuck=booting"

--- a/internal/pkg/machine/controllers/kubernetes_node.go
+++ b/internal/pkg/machine/controllers/kubernetes_node.go
@@ -23,6 +23,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/siderolabs/talos/pkg/machinery/resources/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
 	"go.uber.org/zap"
@@ -119,6 +120,12 @@ func (ctrl *KubernetesNodeController) Inputs() []controller.Input {
 		{
 			Namespace: hardware.NamespaceName,
 			Type:      hardware.ProcessorType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: runtime.NamespaceName,
+			Type:      runtime.KernelCmdlineType,
+			ID:        optional.Some(runtime.KernelCmdlineID),
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -282,6 +289,18 @@ func (ctrl *KubernetesNodeController) computeNodeStatus(ctx context.Context, r c
 		Status:  v1.ConditionTrue,
 		Message: "kubelet is posting ready status",
 	}}
+
+	// A machine broken on purpose reports its node as not ready, like a real broken kubelet would.
+	stuck, err := stuckBooting(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	if stuck {
+		conditions[0].Reason = "KubeletNotReady"
+		conditions[0].Status = v1.ConditionFalse
+		conditions[0].Message = "kubelet is unhealthy: the boot media carries " + constants.StuckBootingKernelArg
+	}
 
 	systemInformation, err := safe.ReaderGetByID[*hardware.SystemInformation](ctx, r, hardware.SystemInformationID)
 	if err != nil && !state.IsNotFoundError(err) {

--- a/internal/pkg/machine/controllers/machine_status.go
+++ b/internal/pkg/machine/controllers/machine_status.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -69,6 +71,12 @@ func (ctrl *MachineStatusController) Inputs() []controller.Input {
 			Namespace: talos.NamespaceName,
 			ID:        optional.Some(talos.RebootID),
 			Type:      talos.RebootStatusType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: runtime.NamespaceName,
+			Type:      runtime.KernelCmdlineType,
+			ID:        optional.Some(runtime.KernelCmdlineID),
 			Kind:      controller.InputWeak,
 		},
 	}
@@ -152,6 +160,20 @@ func (ctrl *MachineStatusController) Run(ctx context.Context, r controller.Runti
 
 				return fmt.Errorf("failed to query %w", err)
 			}
+		}
+
+		stuck, err := stuckBooting(ctx, r)
+		if err != nil {
+			return err
+		}
+
+		if stuck {
+			stage = runtime.MachineStageBooting
+
+			unmetConditions = append(unmetConditions, runtime.UnmetCondition{
+				Name:   "serviceNotReady",
+				Reason: "kubelet is unhealthy: the boot media carries " + emuconst.StuckBootingKernelArg,
+			})
 		}
 
 		if reboot != nil {
@@ -316,4 +338,19 @@ func (ctrl *MachineStatusController) checkServicesReady(ctx context.Context, r c
 	}
 
 	return conditions, nil
+}
+
+// stuckBooting reports whether the emulated boot media carries the magic kernel arg that makes the
+// machine act broken (see [emuconst.StuckBootingKernelArg]).
+func stuckBooting(ctx context.Context, r controller.Runtime) (bool, error) {
+	cmdline, err := safe.ReaderGetByID[*runtime.KernelCmdline](ctx, r, runtime.KernelCmdlineID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return slices.Contains(strings.Fields(cmdline.TypedSpec().Cmdline), emuconst.StuckBootingKernelArg), nil
 }

--- a/internal/pkg/machine/controllers/machine_status_test.go
+++ b/internal/pkg/machine/controllers/machine_status_test.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cosiruntime "github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
+	configv1alpha1 "github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/resources/block"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/siderolabs/talos/pkg/machinery/resources/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/talemu/internal/pkg/constants"
+	"github.com/siderolabs/talemu/internal/pkg/machine/controllers"
+	"github.com/siderolabs/talemu/internal/pkg/machine/runtime/resources/talos"
+)
+
+// TestMachineStatusStuckBooting verifies the magic kernel arg that makes the emulated machine act broken:
+// with the arg in the boot media the machine reports the booting stage and never becomes ready, and once
+// the arg is gone (the fixing schematic is installed) the machine recovers.
+func TestMachineStatusStuckBooting(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	localState := state.WrapCore(namespaced.NewState(inmem.Build))
+	hostState := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	// The disk the config's install section points at.
+	require.NoError(t, hostState.Create(ctx, block.NewDisk(block.NamespaceName, "vda")))
+
+	rt, err := cosiruntime.NewRuntime(localState, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.RegisterController(&controllers.MachineStatusController{State: hostState}))
+
+	runtimeCtx, stopRuntime := context.WithCancel(ctx)
+
+	var eg errgroup.Group
+
+	eg.Go(func() error { return rt.Run(runtimeCtx) })
+
+	t.Cleanup(func() {
+		stopRuntime()
+
+		require.NoError(t, eg.Wait())
+	})
+
+	// A worker config: only the apid service feeds the machine readiness.
+	provider, err := container.New(&configv1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &configv1alpha1.MachineConfig{
+			MachineType: "worker",
+			MachineInstall: &configv1alpha1.InstallConfig{
+				InstallDisk:  "/dev/vda",
+				InstallImage: "factory.talos.dev/installer/abc123:v1.14.0",
+			},
+		},
+		ClusterConfig: &configv1alpha1.ClusterConfig{ClusterID: "test-cluster"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, localState.Create(ctx, config.NewMachineConfig(provider)))
+
+	apid := v1alpha1.NewService(constants.APIDService)
+	apid.TypedSpec().Healthy = true
+	apid.TypedSpec().Running = true
+	require.NoError(t, localState.Create(ctx, apid))
+
+	version := talos.NewVersion(talos.NamespaceName, talos.VersionID)
+	version.TypedSpec().Value.Value = "v1.14.0"
+	require.NoError(t, localState.Create(ctx, version))
+
+	machineStatusID := runtime.NewMachineStatus().Metadata().ID()
+
+	// A healthy machine: running and ready.
+	rtestutils.AssertResource(ctx, t, localState, machineStatusID, func(res *runtime.MachineStatus, a *assert.Assertions) {
+		a.Equal(runtime.MachineStageRunning, res.TypedSpec().Stage)
+		a.True(res.TypedSpec().Status.Ready)
+	})
+
+	// The boot media now carries the magic arg (a bad schematic was installed).
+	cmdline := runtime.NewKernelCmdline()
+	cmdline.TypedSpec().Cmdline = "console=ttyS0 " + constants.StuckBootingKernelArg + " talemu=1"
+	require.NoError(t, localState.Create(ctx, cmdline))
+
+	rtestutils.AssertResource(ctx, t, localState, machineStatusID, func(res *runtime.MachineStatus, a *assert.Assertions) {
+		a.Equal(runtime.MachineStageBooting, res.TypedSpec().Stage)
+		a.False(res.TypedSpec().Status.Ready)
+
+		conditions := res.TypedSpec().Status.UnmetConditions
+		if a.NotEmpty(conditions) {
+			a.Contains(conditions[0].Reason, "kubelet is unhealthy")
+		}
+	})
+
+	// The fixing schematic without the arg is installed: the machine recovers.
+	_, err = safe.StateUpdateWithConflicts(ctx, localState, cmdline.Metadata(), func(res *runtime.KernelCmdline) error {
+		res.TypedSpec().Cmdline = strings.ReplaceAll(res.TypedSpec().Cmdline, constants.StuckBootingKernelArg+" ", "")
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	rtestutils.AssertResource(ctx, t, localState, machineStatusID, func(res *runtime.MachineStatus, a *assert.Assertions) {
+		a.Equal(runtime.MachineStageRunning, res.TypedSpec().Stage)
+		a.True(res.TypedSpec().Status.Ready)
+	})
+}


### PR DESCRIPTION
While talemu.stuck=booting is part of the machine's boot media, the machine stays in the booting stage, never reports ready, and its Kubernetes node reports not ready. Installing a schematic without the arg recovers it.

This gives integration tests a machine that is broken the same way a bad kernel args or extensions change breaks a real one: still connected, but never becoming healthy until the change is reverted.

Part of siderolabs/omni#3262.
