### PR TITLE
feat: accept an image factory API token for schematic reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ services:
 ```
 
 The schematic is read from the image factory at startup, and startup fails if it does not hold that schematic, since machines booted from media nobody has would never come up either.
-Use `--image-factory-base-url` for a factory other than the public one, and `TALEMU_IMAGE_FACTORY_USERNAME` / `TALEMU_IMAGE_FACTORY_PASSWORD` for one that requires authentication.
+Use `--image-factory-base-url` for a factory other than the public one, and `TALEMU_IMAGE_FACTORY_TOKEN` (an API token) or `TALEMU_IMAGE_FACTORY_USERNAME` / `TALEMU_IMAGE_FACTORY_PASSWORD` (basic auth) for one that requires authentication.
 
 ### Without a factory
 

--- a/cmd/talemu/bootmedia.go
+++ b/cmd/talemu/bootmedia.go
@@ -50,8 +50,7 @@ func resolveBootMedia(ctx context.Context, logger *zap.Logger) (*bootMedia, erro
 // its schematic.
 func imagerBootMedia(logger *zap.Logger) (*bootMedia, error) {
 	source, err := bootmedia.NewFactorySource(
-		cfg.schematicCacheDir, cfg.imageFactoryBaseURL,
-		os.Getenv(emuconst.ImageFactoryUsernameEnv), os.Getenv(emuconst.ImageFactoryPasswordEnv),
+		cfg.schematicCacheDir, cfg.imageFactoryBaseURL, factoryCredentials(),
 		logger.With(zap.String("component", "boot_media")),
 	)
 	if err != nil {
@@ -75,8 +74,7 @@ func imagerBootMedia(logger *zap.Logger) (*bootMedia, error) {
 // rediscover it forever. Machines booted from media nobody has would never come up either.
 func factoryBootMedia(ctx context.Context, logger *zap.Logger) (*bootMedia, error) {
 	source, err := bootmedia.NewFactorySource(
-		cfg.schematicCacheDir, cfg.imageFactoryBaseURL,
-		os.Getenv(emuconst.ImageFactoryUsernameEnv), os.Getenv(emuconst.ImageFactoryPasswordEnv),
+		cfg.schematicCacheDir, cfg.imageFactoryBaseURL, factoryCredentials(),
 		logger.With(zap.String("component", "boot_media")),
 	)
 	if err != nil {
@@ -102,4 +100,12 @@ func factoryBootMedia(ctx context.Context, logger *zap.Logger) (*bootMedia, erro
 		schematicID: cfg.schematicID,
 		kernelArgs:  strings.Join(sch.Customization.ExtraKernelArgs, " "),
 	}, nil
+}
+
+func factoryCredentials() bootmedia.Credentials {
+	return bootmedia.Credentials{
+		Username: os.Getenv(emuconst.ImageFactoryUsernameEnv),
+		Password: os.Getenv(emuconst.ImageFactoryPasswordEnv),
+		Token:    os.Getenv(emuconst.ImageFactoryTokenEnv),
+	}
 }

--- a/internal/pkg/bootmedia/factory.go
+++ b/internal/pkg/bootmedia/factory.go
@@ -27,9 +27,15 @@ type FactorySource struct {
 	host    string
 }
 
-// NewFactorySource creates a source reading from the image factory at the given base URL. The credentials are
-// optional and sent as basic auth when set, which an enterprise image factory requires for schematic reads.
-func NewFactorySource(cacheDir, baseURL, username, password string, logger *zap.Logger) (*FactorySource, error) {
+// Credentials authenticate the schematic reads: an API token or a basic auth pair, both optional.
+type Credentials struct {
+	Username string
+	Password string
+	Token    string
+}
+
+// NewFactorySource creates a source reading from the image factory at the given base URL.
+func NewFactorySource(cacheDir, baseURL string, creds Credentials, logger *zap.Logger) (*FactorySource, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid image factory URL %q: %w", baseURL, err)
@@ -41,12 +47,17 @@ func NewFactorySource(cacheDir, baseURL, username, password string, logger *zap.
 
 	var opts []factoryclient.Option
 
-	if username != "" || password != "" {
-		if username == "" || password == "" {
+	switch {
+	case creds.Token != "" && (creds.Username != "" || creds.Password != ""):
+		return nil, fmt.Errorf("either an image factory API token or a basic auth pair is expected, not both")
+	case creds.Token != "":
+		opts = append(opts, factoryclient.WithBearerToken(creds.Token))
+	case creds.Username != "" || creds.Password != "":
+		if creds.Username == "" || creds.Password == "" {
 			return nil, fmt.Errorf("both username and password are required when using image factory basic auth")
 		}
 
-		opts = append(opts, factoryclient.WithBasicAuth(username, password))
+		opts = append(opts, factoryclient.WithBasicAuth(creds.Username, creds.Password))
 	}
 
 	client, err := factoryclient.New(baseURL, opts...)

--- a/internal/pkg/bootmedia/factory_internal_test.go
+++ b/internal/pkg/bootmedia/factory_internal_test.go
@@ -19,12 +19,12 @@ import (
 func TestNewFactorySourceRejectsRelativeURL(t *testing.T) {
 	t.Parallel()
 
-	source, err := NewFactorySource(t.TempDir(), "http://factory.local:8080/base", "user", "password", zaptest.NewLogger(t))
+	source, err := NewFactorySource(t.TempDir(), "http://factory.local:8080/base", Credentials{Username: "user", Password: "password"}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	assert.Equal(t, "http://factory.local:8080/base", source.BaseURL())
 	assert.Equal(t, []string{"factory.local:8080"}, source.FactoryHosts())
 
-	_, err = NewFactorySource(t.TempDir(), "factory.local", "", "", zaptest.NewLogger(t))
+	_, err = NewFactorySource(t.TempDir(), "factory.local", Credentials{}, zaptest.NewLogger(t))
 	require.Error(t, err, "a URL without a scheme would only fail later, at the request")
 }
 
@@ -33,10 +33,13 @@ func TestNewFactorySourceRejectsRelativeURL(t *testing.T) {
 func TestNewFactorySourceRejectsHalfCredentials(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewFactorySource(t.TempDir(), "http://factory.local:8080", "user", "", zaptest.NewLogger(t))
+	_, err := NewFactorySource(t.TempDir(), "http://factory.local:8080", Credentials{Username: "user"}, zaptest.NewLogger(t))
 	require.Error(t, err)
 
-	_, err = NewFactorySource(t.TempDir(), "http://factory.local:8080", "", "password", zaptest.NewLogger(t))
+	_, err = NewFactorySource(t.TempDir(), "http://factory.local:8080", Credentials{Password: "password"}, zaptest.NewLogger(t))
+	require.Error(t, err)
+
+	_, err = NewFactorySource(t.TempDir(), "http://factory.local:8080", Credentials{Username: "user", Password: "password", Token: "token"}, zaptest.NewLogger(t))
 	require.Error(t, err)
 }
 
@@ -88,7 +91,7 @@ func TestFactoryEnterprise(t *testing.T) {
 
 	// The configured factory is reached by its base URL, so a plain-HTTP one keeps working. Any other host is
 	// only known by name, so it is assumed to be HTTPS and is not reachable in this test.
-	source, err := NewFactorySource(t.TempDir(), enterprise.URL, "", "", zaptest.NewLogger(t))
+	source, err := NewFactorySource(t.TempDir(), enterprise.URL, Credentials{}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	// no factory host means the image came from no factory, so there is nothing to probe
@@ -107,14 +110,14 @@ func TestFactoryEnterprise(t *testing.T) {
 
 	// A community factory and one that refuses the probe, each reached as the configured factory of their own
 	// source so that the plain-HTTP base URL is used.
-	communitySource, err := NewFactorySource(t.TempDir(), community.URL, "", "", zaptest.NewLogger(t))
+	communitySource, err := NewFactorySource(t.TempDir(), community.URL, Credentials{}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	isEnterprise, err = communitySource.IsEnterprise(t.Context(), "v1.14.0", hostOf(t, community.URL))
 	require.NoError(t, err)
 	assert.False(t, isEnterprise)
 
-	refusedSource, err := NewFactorySource(t.TempDir(), refused.URL, "", "", zaptest.NewLogger(t))
+	refusedSource, err := NewFactorySource(t.TempDir(), refused.URL, Credentials{}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	isEnterprise, err = refusedSource.IsEnterprise(t.Context(), "v1.14.0", hostOf(t, refused.URL))
@@ -126,11 +129,49 @@ func TestFactoryProbeURLFor(t *testing.T) {
 	t.Parallel()
 
 	// A plain-HTTP configured factory, to check it is used as it was given rather than assumed to be HTTPS.
-	source, err := NewFactorySource(t.TempDir(), "http://factory.local:8080", "", "", zaptest.NewLogger(t))
+	source, err := NewFactorySource(t.TempDir(), "http://factory.local:8080", Credentials{}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	assert.Empty(t, source.probeURLFor(""), "no host means no factory")
 	assert.Equal(t, "http://factory.local:8080", source.probeURLFor("factory.local:8080"))
 	assert.Equal(t, "https://factory.example.com", source.probeURLFor("factory.example.com"),
 		"an image reference carries no scheme, so another factory is assumed to be HTTPS")
+}
+
+func TestFactoryCredentialsOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		creds         Credentials
+		authorization string
+	}{
+		{name: "none", creds: Credentials{}},
+		{name: "basic auth", creds: Credentials{Username: "user", Password: "hunter2"}, authorization: "Basic dXNlcjpodW50ZXIy"},
+		{name: "token", creds: Credentials{Token: "omni-token"}, authorization: "Bearer omni-token"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var received atomic.Pointer[string]
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				header := r.Header.Get("Authorization")
+				received.Store(&header)
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`[]`)) //nolint:errcheck
+			}))
+			t.Cleanup(server.Close)
+
+			source, err := NewFactorySource(t.TempDir(), server.URL, tt.creds, zaptest.NewLogger(t))
+			require.NoError(t, err)
+
+			_, err = source.client.Versions(t.Context())
+			require.NoError(t, err)
+
+			require.NotNil(t, received.Load())
+			require.Equal(t, tt.authorization, *received.Load())
+		})
+	}
 }

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -38,6 +38,10 @@ const ImageFactoryUsernameEnv = "TALEMU_IMAGE_FACTORY_USERNAME"
 // image factory. See [ImageFactoryUsernameEnv].
 const ImageFactoryPasswordEnv = "TALEMU_IMAGE_FACTORY_PASSWORD"
 
+// ImageFactoryTokenEnv is the environment variable carrying the optional image factory API token, the
+// alternative to the basic auth pair.
+const ImageFactoryTokenEnv = "TALEMU_IMAGE_FACTORY_TOKEN"
+
 // StuckBootingKernelArg is a magic kernel arg that makes the emulated machine act broken as long as the
 // arg is part of its boot media: the machine stays in the booting stage, never reports ready, and its
 // Kubernetes node reports not ready. It simulates a machine broken by a bad kernel args or extensions


### PR DESCRIPTION
An enterprise image factory can now be reached with an API token, passed through TALEMU_IMAGE_FACTORY_TOKEN, instead of the basic auth pair. Omni is moving to these tokens, and the local dev setup hands the emulator the same token it hands Omni. The pair keeps working, giving both at once is rejected.

To clarify, an infra provider normally needs no factory credentials. The emulator is the exception because it stands in for Talos: it reads schematics to report the extensions and kernel args a real machine would, and for that it needs to talk to the factory.

Part of siderolabs/omni#3346.
